### PR TITLE
mutt: avoid host contamination when looking for maildir

### DIFF
--- a/README.install
+++ b/README.install
@@ -65,7 +65,7 @@ the components that make up the core system (dom0, dom1, domE, essential).
 
 The OverC installer is available from the following repository:
 
-  https://github.com/WindRiver-OpenSourceLabs/overc-installer.git
+  https://github.com/OverC/overc-installer.git
 
 Once cloned, the installer must be configured for your target device (Sample
 configurations are provided).
@@ -77,7 +77,7 @@ to a USB stick results in an installer that boots and runs on most x86 targets.
  % WORKDIR=<your_working_directory>
  % CLONEDIR=<your_clone_directory> #e.g. CLONEDIR=$WORKDIR
  % cd $CLONEDIR
- % git clone git://github.com/WindRiver-OpenSourceLabs/overc-installer.git
+ % git clone git://github.com/OverC/overc-installer.git
  % mkdir -p $WORKDIR/usbhdinstaller
  % cd $WORKDIR/usbhdinstaller
  % mkdir .overc

--- a/meta-cube/recipes-connectivity/consul/consul_git.bb
+++ b/meta-cube/recipes-connectivity/consul/consul_git.bb
@@ -35,6 +35,7 @@ DEPENDS += "circbuf \
     hashicorp-go-memdb \
     hashicorp-go-reap \
     hashicorp-go-uuid \
+    net-rpc-msgpackrpc \
     "
 
 PKG_NAME = "github.com/hashicorp/consul"

--- a/meta-cube/recipes-connectivity/consul/scada-client_git.bb
+++ b/meta-cube/recipes-connectivity/consul/scada-client_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Implements a Golang client to the HashiCorp SCADA system"
 HOMEPAGE = "https://github.com/hashicorp/scada-client"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/scada-client"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/copystructure_git.bb
+++ b/meta-cube/recipes-devtools/go/copystructure_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Go (golang) library for deep copying values in Go."
 HOMEPAGE = "https://github.com/mitchellh/copystructure"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3f7765c3d4f58e1f84c4313cecf0f5bd"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=56da355a12d4821cda57b8f23ec34bc4"
 
 PKG_NAME = "github.com/mitchellh/copystructure"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/dockerclient_git.bb
+++ b/meta-cube/recipes-devtools/go/dockerclient_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Go client for the Docker remote API."
 HOMEPAGE = "https://github.com/fsouza/go-dockerclient"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3f7765c3d4f58e1f84c4313cecf0f5bd"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=9687fb4c7ee49afa7b6afd459d1f7169"
 
 PKG_NAME = "github.com/fsouza/go-dockerclient"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/go-bindata_git.bb
+++ b/meta-cube/recipes-devtools/go/go-bindata_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Serve embedded files from jteeuwen/go-bindata with net/http."
 HOMEPAGE = "https://github.com/elazarl/go-bindata-assetfs"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3f7765c3d4f58e1f84c4313cecf0f5bd"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=722abb44e97dc8f098516e09e5564a6a"
 
 PKG_NAME = "github.com/elazarl/go-bindata-assetfs"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/go-multierror_git.bb
+++ b/meta-cube/recipes-devtools/go/go-multierror_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "A Go (golang) package for representing a list of errors as a single error."
 HOMEPAGE = "https://github.com/hashicorp/go-multierror"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d44fdeb607e2d2614db9464dbedd4094"
 
 PKG_NAME = "github.com/hashicorp/go-multierror"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-errwrap_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-errwrap_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Errwrap is a Go (golang) library for wrapping and querying errors."
 HOMEPAGE = "https://github.com/hashicorp/errwrap"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b278a92d2c1509760384428817710378"
 
 PKG_NAME = "github.com/hashicorp/errwrap"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-cleanhttp_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-cleanhttp_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Functions for accessing clean Go http.Client values"
 HOMEPAGE = "https://github.com/hashicorp/go-cleanhttp"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/go-cleanhttp"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-immutable-radix_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-immutable-radix_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "An immutable radix tree implementation in Golang"
 HOMEPAGE = "https://github.com/hashicorp/go-immutable-radix"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/go-immutable-radix"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-memdb_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-memdb_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Golang in-memory database built on immutable radix trees"
 HOMEPAGE = "https://github.com/hashicorp/go-memdb"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/go-memdb"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-reap_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-reap_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Child process reaping utilities for Go"
 HOMEPAGE = "https://github.com/hashicorp/go-reap"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/go-reap"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-uuid_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-uuid_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Generates UUID-format strings using purely high quality random bytes"
 HOMEPAGE = "https://github.com/hashicorp/go-uuid"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea"
 
 PKG_NAME = "github.com/hashicorp/go-uuid"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
@@ -26,3 +26,5 @@ hashicorp_hcl_sysroot_preprocess () {
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"
+
+CLEANBROKEN = "1"

--- a/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "HCL (HashiCorp Configuration Language) is a configuration language built by HashiCorp"
 HOMEPAGE = "https://github.com/hashicorp/hcl"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b278a92d2c1509760384428817710378"
 
 PKG_NAME = "github.com/hashicorp/hcl"
 SRC_URI = "git://${PKG_NAME}.git"

--- a/meta-cube/recipes-devtools/go/hashicorp-hil_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-hil_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "HIL is a small embedded language for string interpolations."
 HOMEPAGE = "https://github.com/hashicorp/hil"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
+LICENSE = "MPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d44fdeb607e2d2614db9464dbedd4094"
 
 DEPENDS += "go-net"
 

--- a/meta-cube/recipes-support/overc-installer/overc-installer_git.bb
+++ b/meta-cube/recipes-support/overc-installer/overc-installer_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://github.com/WindRiver-OpenSourceLabs/overc-installer.git \
+    git://github.com/OverC/overc-installer.git \
     file://git/COPYING \
 "
 

--- a/meta-cube/recipes-support/overc-utils/overc-utils_git.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_git.bb
@@ -6,7 +6,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}:"
 
 SRCREV = "${AUTOREV}"
 SRC_URI = " \
-    git://github.com/WindRiver-OpenSourceLabs/overc-installer.git;branch=master \
+    git://github.com/OverC/overc-installer.git;branch=master \
     file://source/cube-cmd \
     file://source/cube-ctl \
     file://source/cube \


### PR DESCRIPTION
The configure script will look in hard coded locations for the
maildir, all of which are locations on the host. Rather then allow
this to happen we will pass the expected maildir.

This also fixes a build issue if none of the hardcoded paths exist on
the builder. Preventing the build error:

    configure: error: "Could not determine where new mail is stored."

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>