### PR TITLE
README: Remove meta-security from the dependent layer list

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,6 @@ layers: meta-oe
         meta-gnome
         meta-xfce
         meta-multimedia
-        meta-security
 
 URI: git://git.yoctoproject.org/meta-virtualization
 branch: master


### PR DESCRIPTION
meta-security was moved out of meta-openembedded repo.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>