### PR TITLE
cgmanager: fix sbin location

### DIFF
--- a/meta-cube/recipes-core/cgmanager/cgmanager_0.37.bb
+++ b/meta-cube/recipes-core/cgmanager/cgmanager_0.37.bb
@@ -19,7 +19,7 @@ DEPENDS += "libnih libnih-native"
 # The test scripts need some extra facilities
 RDEPENDS_${PN} += "libnih bash sudo util-linux"
 
-EXTRA_OECONF += "--with-distro=${DISTRO} --with-init-script=\
+EXTRA_OECONF += "--sbindir=/sbin --with-distro=${DISTRO} --with-init-script=\
 ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit,', '', d)}\
 ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}"
 


### PR DESCRIPTION
Currently the systemd service script of cgmanager uses hardcoded /sbin
prefix for the binary. So we fix the location in the configure stage.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>