### PR TITLE
cube-ctl: add -u option to support unprivileged containers

### DIFF
--- a/meta-cube/recipes-support/dom0-contctl/dom0-contctl_1.0.bb
+++ b/meta-cube/recipes-support/dom0-contctl/dom0-contctl_1.0.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "A tool for deploying, querying, etc lxc containers from Domain 0"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
-RDEPENDS_${PN} = "util-linux lxc bash python"
+RDEPENDS_${PN} = "util-linux lxc bash python cgmanager"
 
 SRC_URI = "file://dom0_contctl \
            file://lxc_driver.sh \

--- a/meta-cube/recipes-support/dom0-contctl/files/dom0-containers
+++ b/meta-cube/recipes-support/dom0-contctl/files/dom0-containers
@@ -55,6 +55,8 @@ case "$1" in
 	    exit 0;
 	fi
 
+        cgmanager -m name=systemd --daemon
+
         if [ -n "$BOOTGROUPS" ]; then
             BOOTGROUPS="-g $BOOTGROUPS"
         fi

--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -31,7 +31,7 @@ commands (and options):
 
        <name>: name of the container to be stopped
 
- ${0##*/} add [-n <name>] <source tar.bz2>
+ ${0##*/} add [-n <name>] [-u <subuid>] <source tar.bz2>
 
     add a container to the platform. Once added, the container is monitored, but
     not started. Use "cube-ctl start" to launch a container after adding it.
@@ -39,6 +39,11 @@ commands (and options):
        -n <name>: name of the container once added to the system. If this is
                   not supplied, the container source tarball is used to generate
                   a name.
+
+       -u: make this newly added container unprivileged. The subuid field will
+           be used to set the owner of the uid/gid in the root namespace for the
+           newly added container. If no subuid field is provided, a default
+           value of 800000 will be used.
 
        <source>: path to the container source (tar.bz2)
 
@@ -82,6 +87,10 @@ raw_command=($@)
 force=""
 peer=t
 non_dashed=""
+
+# this corresponds to the lxc.id_map items within the container's config file
+DEFAULT_SUBUID=800000
+
 while [ $# -gt 0 ]; do
     case "$1" in
 	-v) verbose=t
@@ -98,6 +107,19 @@ while [ $# -gt 0 ]; do
 	    parent=${2}
 	    shift
 	    ;;
+	-u)
+		# This is an unprivileged container. We need to config subuid/subgid.
+		if [ "${2}" -eq "${2}" ] 2>/dev/null; then
+			if [ "${2}" -lt 100000 ] 2>/dev/null; then
+				echo "Error: -u requires a subuid number no less than 100000"
+				exit 1
+			fi
+			subuid="${2}"
+			shift
+		else
+			subuid="${DEFAULT_SUBUID}"
+		fi
+		;;
 	-F)
 	    force=-F
 	    ;;
@@ -242,7 +264,15 @@ case "${cmd}" in
 	    container_name="`cubename ${filename}`"
 	fi
 
-	${overc_cctl} add -d -a -c -g onboot -t 0 -n ${container_name} -f ${container_source}
+	# unprivileged. create default subuid/subgids for root and pass the
+	# parameter to overc_ctl for container settings
+	if [ -n "${subuid}" ]; then
+		privilege_param="-u ${subuid}"
+		cube-cmd cmd "touch /etc/subuid /etc/subgid"
+		cube-cmd cmd "usermod --add-subuids ${subuid}-$(( subuid+65536 )) root"
+		cube-cmd cmd "usermod --add-subgids ${subuid}-$(( subuid+65536 )) root"
+	fi
+	${overc_cctl} add ${privilege_param} -d -a -c -g onboot -t 0 -n ${container_name} -f ${container_source}
 	if [ $? != 0 ]; then
 	    echo "Add container failed ..."
 	    exit 1


### PR DESCRIPTION
Currently we only support privileged containers, we should also support unprivileged ones. "cube-ctl add" is the entry for this. Once we added a container with the correct type, we can do other operations such as del/start/stop using the same interface with privileged ones.