### PR TITLE
libnih: fix patch missing error

### DIFF
--- a/meta-cube/recipes-core/libnih/libnih_%.bbappend
+++ b/meta-cube/recipes-core/libnih/libnih_%.bbappend
@@ -1,2 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://Set-pkgconfigdir-to-use-the-proper-libdir.patch \
            "


### PR DESCRIPTION
The upstream now has the libnih 1.0.3 version, which prevents the
libnih version in our layer. Somehow our bbappend is still valid, so
the patch provided through the bbappend will not be discovered due to
seach path error. Add the correct search path.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>