### PR TITLE
cube-cmd: kill -v option

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-cmd
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cmd
@@ -75,27 +75,12 @@ cat << EOF
 EOF
 }
 
-if [ -z "$1" ]; then
+# take the remaining command into an array
+raw_command=($@)
+
+if [ ${#raw_command[*]} -lt 1 ]; then
     usage
     exit
 fi
-
-# take the entire command into an array
-raw_command=($@)
-while [ $# -gt 0 ]; do
-    case "$1" in
-	-v) verbose=t
-            ;;
-    esac
-    shift
-done
-
-check_required()
-{
-    if [ ! -e "${1}" ]; then
-	echo "[ERROR]: required command ${1} not found, exiting"
-	exit 1
-    fi
-}
 
 do_essential_cmd ${raw_command[@]}


### PR DESCRIPTION
Specifying -v option, e.g, cube-cmd -v cmd ls, will break cube-cmd.
In fact it is a hold over from another script. cube-cmd shouldn't
actually have any options that it processes itself, everything must
go to the sub commands. So we can drop the -v safely.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>