### PR TITLE
cube: fix the execution of cube-cmd

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube
+++ b/meta-cube/recipes-support/overc-utils/source/cube
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2 as
 #  published by the Free Software Foundation.
@@ -54,7 +52,7 @@ case ${command} in
 	;;
     cmd)
 	shift
-	cube-cmd $@
+	cube-cmd "$@"
 	;;
     add)
         cube-ctl $@


### PR DESCRIPTION
Executing "cube cmd cmd 'ls -l /proc'" cannot get the expected result
because the whole parameter list is not considered.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>