### PR TITLE
meta-overc: reorder the network device list

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/network_prime/files/autonetdev
+++ b/meta-cube/recipes-support/overc-conftools/source/network_prime/files/autonetdev
@@ -16,7 +16,7 @@ fi
 
 sed -i -e '/^lxc.network.type = phys/d; /^lxc.network.link =/d' $config
 
-for dev in `(cd /sys/class/net && ls -d $linkdevs 2>/dev/null)`; do
+for dev in `(cd /sys/class/net && ls -dr $linkdevs 2>/dev/null)`; do
     echo lxc.network.type = phys >> $config
     echo lxc.network.link = $dev >> $config
 done

--- a/meta-cube/recipes-support/overc-installer/overc-installer_git.bb
+++ b/meta-cube/recipes-support/overc-installer/overc-installer_git.bb
@@ -12,8 +12,12 @@ S = "${WORKDIR}/git"
 
 do_install() {
 	mkdir -p ${D}/opt/${BPN}/
+	mkdir -p ${D}/lib/systemd/system/
 	install -m755 ${S}/sbin/overc-cctl ${D}/opt/${BPN}/
+	install -m 0755 ${S}/files/overc_cleanup.service ${D}/lib/systemd/system/
 }
 
-FILES_${PN} += "/opt/${BPN}"
+FILES_${PN} += "/opt/${BPN} \
+		/lib/systemd/system \
+	    "
 RDEPENDS_${PN} += "bash"

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -87,6 +87,7 @@ class Overc(object):
                             print "*** Failed to rollback container %s" % cn
                         else:
                             need_reboot=True
+                        break
 
 
         self.host_rollback()


### PR DESCRIPTION
If more than 2 physical network interfaces were
assigned to a container, such as "eth0", "eth1"
and "eth2", and when this container stop, these
three network interfaces would return to essential
system with interfaces named changed to "eth1", "eth2"
and "dev5".

If the order of the interfaces were reverted to assinged
to container, when the container stop and reture those
interfaces to essential system the kernel would not
change those interfaces name.

Signed-off-by: fli <fupan.li@windriver.com>