### PR TITLE
[meta-overc]Make upgrade working on overlayfs

### DIFF
--- a/meta-cube/recipes-core/lxc/files/lxc-overlayscan
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayscan
@@ -1,0 +1,66 @@
+#!/bin/sh -
+
+# /usr/lib64/lxc/lxc/lxc-overlayscan
+# Scan duplicate file in overlay dir for every container
+
+scandir()
+{
+# Search each entry in base_path, delete same file in target_path.
+for entry in $(ls $1 -A); do
+    if [ -e "$2/${entry}" ]; then
+        if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+            [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Only enter dir when both $1/entry & $2/entry are directory
+            scandir "$1/$entry" "$2/$entry"
+        elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+              [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are regular file
+            # Check md5sum
+	    md5sum1=`md5sum $1/${entry}|awk '{print $1}'`
+	    md5sum2=`md5sum $2/${entry}|awk '{print $1}'`
+	    if [ $md5sum1 = $md5sum2 ]; then
+                rm "$2/${entry}"
+            fi
+        elif [ -L "$2/${entry}" ] && [ -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are sympol-link
+            link1=`readlink $1/${entry}`
+            link2=`readlink $2/${entry}`
+	    if [ $link1 = $link2 ]; then
+                rm "$2/${entry}"
+	    fi
+        fi
+        # Ignore other conditions
+    fi
+done;
+# Remove empty diretory in target_path
+if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
+    rmdir "$2"
+fi
+}
+
+# 1.List all containers
+for cn in $(lxc-ls); do
+# 2.Open /var/lib/lxc/$container/fstab, list all overlay mount entry
+	options=`cat /var/lib/lxc/${cn}/fstab|awk '{if ( $1=="'overlay'" )print $4}'`
+	for option in $options; do
+		dirs=`echo ${option}|sed 's/,/\n/g'`
+		for dir in $dirs; do
+			dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'lowerdir'" )print $2}'`
+			if [ ! -z ${dirout} ]; then
+				dirlow=$dirout
+			fi
+			dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'upperdir'" )print $2}'`
+			if [ ! -z ${dirout} ]; then
+				dirup=$dirout
+			fi
+		done;
+# 3.For each entry, list all lowerdir, scandir $1=lowerdir, $2=uppderdir
+		dirlows=`echo ${dirlow}|sed 's/:/\n/g'`
+		for low in ${dirlows}; do
+			scandir ${low} ${dirup}
+		done;
+	done;
+done;
+
+# Remove service from lxc.service
+sed -i "/lxc-overlayscan/d" /lib/systemd/system/lxc.service

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -11,6 +11,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://ovs-up \
     file://ovs-down \
+    file://lxc-overlayscan \
     file://silence_no_escape_lxc-console.patch \
     file://read-write-file-handles-after-EPOLLHUP.patch \
     "
@@ -34,4 +35,7 @@ do_install_append(){
 	install -d ${D}/etc/lxc/
 	install -m 755 ${WORKDIR}/ovs-up ${D}/etc/lxc/ovs-up
 	install -m 755 ${WORKDIR}/ovs-down ${D}/etc/lxc/ovs-down
+
+	# add script to scan dir mount with overlay to delete duplicate file
+	install -m 755 ${WORKDIR}/lxc-overlayscan ${D}/etc/lxc/lxc-overlayscan
 }

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -70,6 +70,15 @@ class Container(object):
             self.message += "\nUpdate failed"
         return retval
 
+    def pre_upgrade(self, name, template):
+        fstabfile="/var/lib/lxc/%s/fstab" % name
+        fstab=open(fstabfile, 'r')
+        for line in fstab:
+            member=line.split()
+            if member[0]=="overlay":
+                return 1
+        return 0
+
     def upgrade(self, name, template, rpm_upgrade=True, image_upgrade=False):
         if image_upgrade and not rpm_upgrade:
             retval = self.update(template)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -230,7 +230,12 @@ class Overc(object):
         self.message = self.container.message
 
     def container_upgrade(self):
-        self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image)
+        # Perform overlay check fist
+        if self.container.pre_upgrade(self.args.name, self.args.template) is 1:
+            print "Container %s got overlayed dir, must use system upgrade." % self.args.name
+            self.retval = 0
+        else:
+            self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image)
         sys.exit(self.retval)
     def _container_upgrade(self, container, template, rpm=True, image=False):
         self.retval = self.container.upgrade(container, template, rpm, image)


### PR DESCRIPTION
To allow upgrade working on overlayfs dir, add following into overc-system-agent:

1.For 'container upgrade', perform a pre-upgrade checking for container. If container got dir mount with overlayfs from other containers, issue a warning to remind user perform 'system upgrade'.
If there is no dir shared with other containers, the 'container upgrade' command act as usual.

2.After system upgrade, if system got container share dir with overlayfs, there are duplicate file in upperdir after upgrade. To delete such file to save disk space, overc-system-agent insert a service in before lxc lanuched after reboot. The service will scan upper dir for all containers to remove duplicate file.

BR,
Jiang Lu