### PR TITLE
 [v3]Make upgrade working on overlayfs

### DIFF
--- a/meta-cube/recipes-core/lxc/files/lxc-overlayscan
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayscan
@@ -1,0 +1,66 @@
+#!/bin/sh -
+
+# /usr/lib64/lxc/lxc/lxc-overlayscan
+# Scan duplicate file in overlay dir for every container
+
+scandir()
+{
+# Search each entry in base_path, delete same file in target_path.
+for entry in $(ls $1 -A); do
+    if [ -e "$2/${entry}" ]; then
+        if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+            [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Only enter dir when both $1/entry & $2/entry are directory
+            scandir "$1/$entry" "$2/$entry"
+        elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+              [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are regular file
+            # Check md5sum
+	    md5sum1=`md5sum $1/${entry}|awk '{print $1}'`
+	    md5sum2=`md5sum $2/${entry}|awk '{print $1}'`
+	    if [ $md5sum1 = $md5sum2 ]; then
+                rm "$2/${entry}"
+            fi
+        elif [ -L "$2/${entry}" ] && [ -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are sympol-link
+            link1=`readlink $1/${entry}`
+            link2=`readlink $2/${entry}`
+	    if [ $link1 = $link2 ]; then
+                rm "$2/${entry}"
+	    fi
+        fi
+        # Ignore other conditions
+    fi
+done;
+# Remove empty diretory in target_path
+if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
+    rmdir "$2"
+fi
+}
+
+# 1.List all containers
+for cn in $(lxc-ls); do
+# 2.Open /var/lib/lxc/$container/fstab, list all overlay mount entry
+	options=`cat /var/lib/lxc/${cn}/fstab|awk '{if ( $1=="'overlay'" )print $4}'`
+	for option in $options; do
+		dirs=`echo ${option}|sed 's/,/\n/g'`
+		for dir in $dirs; do
+			dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'lowerdir'" )print $2}'`
+			if [ ! -z ${dirout} ]; then
+				dirlow=$dirout
+			fi
+			dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'upperdir'" )print $2}'`
+			if [ ! -z ${dirout} ]; then
+				dirup=$dirout
+			fi
+		done;
+# 3.For each entry, list all lowerdir, scandir $1=lowerdir, $2=uppderdir
+		dirlows=`echo ${dirlow}|sed 's/:/\n/g'`
+		for low in ${dirlows}; do
+			scandir ${low} ${dirup}
+		done;
+	done;
+done;
+
+# Remove service from lxc.service
+sed -i "/lxc-overlayscan/d" /lib/systemd/system/lxc.service

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -11,6 +11,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://ovs-up \
     file://ovs-down \
+    file://lxc-overlayscan \
     file://silence_no_escape_lxc-console.patch \
     file://read-write-file-handles-after-EPOLLHUP.patch \
     "
@@ -34,4 +35,7 @@ do_install_append(){
 	install -d ${D}/etc/lxc/
 	install -m 755 ${WORKDIR}/ovs-up ${D}/etc/lxc/ovs-up
 	install -m 755 ${WORKDIR}/ovs-down ${D}/etc/lxc/ovs-down
+
+	# add script to scan dir mount with overlay to delete duplicate file
+	install -m 755 ${WORKDIR}/lxc-overlayscan ${D}/etc/lxc/lxc-overlayscan
 }

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -2,6 +2,7 @@ import sys, os
 import subprocess
 import os.path
 from Overc.utils import Process
+from Overc.utils  import CONTAINER_MOUNT
 
 # containers template named scripts
 CONTAINER_SCRIPT_PATH = "/etc/overc/container/"
@@ -69,6 +70,22 @@ class Container(object):
         else:
             self.message += "\nUpdate failed"
         return retval
+
+    def get_overlay(self, name):
+        fstabfile="%s/%s/fstab" % (CONTAINER_MOUNT,name)
+        fstab=open(fstabfile, 'r')
+        dirlist=[]
+        for line in fstab:
+            member=line.split()
+            if member[0]=="overlay":
+                strpre="%s/%s/rootfs" % (CONTAINER_MOUNT,name)
+                strdir=member[1][member[1].find(strpre) + len(strpre):len(member[1])]
+                dirlist.append(strdir)
+        return dirlist
+
+    def is_overlay(self, name):
+        dirlist=self.get_overlay(name)
+        return len(dirlist)
 
     def upgrade(self, name, template, rpm_upgrade=True, image_upgrade=False):
         if image_upgrade and not rpm_upgrade:

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -5,6 +5,7 @@ from Overc.container import Container
 from Overc.utils import Utils
 from Overc.utils import ROOTMOUNT
 from Overc.utils import HOSTPID
+from Overc.utils  import SYSROOT
 
 def Is_btrfs():
     return not os.system('btrfs subvolume show %s >/dev/null 2>&1' % ROOTMOUNT)
@@ -56,6 +57,7 @@ class Overc(object):
 
     def _system_upgrade(self, template, reboot, force):
         containers = self.container.get_container(template)
+        overlay_flag = 0
 	#By now only support "Pulsar" and "overc" Linux upgrading
         DIST = "Pulsar overc"
         for cn in containers:
@@ -68,9 +70,30 @@ class Overc(object):
                             print "*** Failed to upgrade container %s" % cn
                             print "*** Abort the system upgrade action"
                             sys.exit(self.retval)
+                        else:
+                            if self.container.is_overlay(cn) > 0:
+                                overlay_flag = 1
                         break
 
         self._host_upgrade(reboot, force)
+
+        if overlay_flag == 1:
+            # Enable lxc-overlay service in essential
+            lxcfile = '%s/%s/lib/systemd/system/lxc.service' % (SYSROOT, self.agency.next_rootfs)
+            lxc = open(lxcfile, 'r')
+            lines = lxc.readlines()
+            lxc.close()
+            for line in lines:
+                if line.find("lxc_overlay") != -1:
+                    sys.exit(self.retval)
+            for line in lines:
+                if line.find("ExecStart") != -1:
+                    index = lines.index(line)
+                    break
+            lines.insert(index, "ExecStartPre=/etc/lxc/lxc-overlayscan\n")
+            lxc = open(lxcfile, 'w')
+            lxc.writelines(lines)
+            lxc.close()
 
     def system_rollback(self):
         containers = self.container.get_container(self.args.template)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -230,7 +230,15 @@ class Overc(object):
         self.message = self.container.message
 
     def container_upgrade(self):
-        self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image)
+        # Perform overlay check fist
+        overlaylist = self.container.get_overlay(self.args.name)
+        if len(overlaylist)>0:
+            print "Container %s has overlayed dir, including" % self.args.name
+            print(overlaylist)
+            print "This container can only be upgraded via a system upgrade"
+            self.retval = 0
+        else:
+            self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image)
         sys.exit(self.retval)
     def _container_upgrade(self, container, template, rpm=True, image=False):
         self.retval = self.container.upgrade(container, template, rpm, image)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -53,9 +53,10 @@ class Overc(object):
             self.command = None
 
     def system_upgrade(self):
-        self._system_upgrade(self.args.template, self.args.reboot, self.args.force)
+        self._system_upgrade(self.args.template, self.args.reboot, self.args.force, self.args.skipscan)
 
-    def _system_upgrade(self, template, reboot, force):
+    def _system_upgrade(self, template, reboot, force, skipscan):
+	print "skipscan %d" % skipscan
         containers = self.container.get_container(template)
         overlay_flag = 0
 	#By now only support "Pulsar" and "overc" Linux upgrading
@@ -77,7 +78,7 @@ class Overc(object):
 
         self._host_upgrade(reboot, force)
 
-        if overlay_flag == 1:
+        if ((overlay_flag == 1) and (skipscan == 0)):
             # Enable lxc-overlay service in essential
             lxcfile = '%s/%s/lib/systemd/system/lxc.service' % (SYSROOT, self.agency.next_rootfs)
             lxc = open(lxcfile, 'r')

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
@@ -64,6 +64,9 @@ if __name__ == '__main__':
 	s_upgradep.add_argument("-f", "--force", dest="force",
 	                        action="store_true",
 			        help=_("do system backup and upgrade even the system is up to date"))
+	s_upgradep.add_argument("-s", "--skipscan", dest="skipscan",
+				action="store_true",
+				help=_("if an upgrade involve container use overlayfs, skip duplicate file scan after deployment"))
 
         s_roolback = system_subparse.add_parser("rollback", help=_("switch to the top of the history rollback list, including host and containers"))
         s_roolback.set_defaults(func=overc.system_rollback)


### PR DESCRIPTION
[Change in v3]
1. Upgrade message according to Bruce's advice.
2.Add -s option for 'system upgrade', when enabled, overc will skip duplicate scan after upgrade.

[Change in v2]
1.Add more info in warning message to list which directories is overlay-ed. For example:
root@cube-dom0:/opt/overc-system-agent# ./overc container upgrade dom0 dom0
Container dom0 got overlayed dir, including
['/usr']
Must use system upgrade.

2.Use CONTAINER_MOUNT & SYSROOT from Utils.py in file reference.

[v1 log]
To allow upgrade working on overlayfs dir, add following into overc-system-agent:

1.For 'container upgrade', perform a pre-upgrade checking for container. If container got dir mount with overlayfs from other containers, issue a warning to remind user perform 'system upgrade'.
If there is no dir shared with other containers, the 'container upgrade' command act as usual.

2.After system upgrade, if system got container share dir with overlayfs, there are duplicate file in upperdir after upgrade. To delete such file to save disk space, overc-system-agent insert a service in before lxc lanuched after reboot. The service will scan upper dir for all containers to remove duplicate file.

BR,
Jiang Lu