### PR TITLE
overc-conftools: use a physical mac address as system id

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/overc-conftools_1.0.bb
+++ b/meta-cube/recipes-support/overc-conftools/overc-conftools_1.0.bb
@@ -30,6 +30,7 @@ SRC_URI = " \
     file://source/network_prime/manifests/init.pp \
     file://source/network_prime/templates/network_prime.sh.erb \
     file://source/network_prime/templates/network_prime_port_forward.sh.erb \
+    file://source/system/systemid-set.sh \
 "
 
 S = "${WORKDIR}"
@@ -56,6 +57,14 @@ do_install() {
          install -m 644 ${WORKDIR}/source/network_prime/templates/$template \
                    ${D}/${sysconfdir}/puppet/modules/network_prime/templates/
     done
+
+    install -d ${D}/${sysconfdir}/puppet/modules/system
+    install -m 755 ${WORKDIR}/source/system/systemid-set.sh ${D}/${sysconfdir}/puppet/modules/system
+
+    #to create an empty system-id file to tell overc-installer
+    #to bind mount it to dom0/cube-desktop to share one system
+    #id between them.
+    touch ${D}/${sysconfdir}/system-id
 
     # Puppet manifests
     install -d ${D}/${sysconfdir}/puppet/manifests

--- a/meta-cube/recipes-support/overc-conftools/source/manifests/site.pp
+++ b/meta-cube/recipes-support/overc-conftools/source/manifests/site.pp
@@ -37,3 +37,8 @@ exec { 'restart-networking':
 exec { 'restart-dnsmasq':
   command => '/bin/systemctl restart dnsmasq',
 }
+
+exec {
+    'set system id':
+    command => '/etc/puppet/modules/system/systemid-set.sh',
+}

--- a/meta-cube/recipes-support/overc-conftools/source/system/systemid-set.sh
+++ b/meta-cube/recipes-support/overc-conftools/source/system/systemid-set.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+linkdevs="wl* en* eth*"
+
+#Use one physical mac address as the system id
+for dev in `(cd /sys/class/net && ls -d $linkdevs 2>/dev/null)`; do
+    cat  /sys/class/net/$dev/address >/etc/system-id
+    break
+done
+

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -134,6 +134,7 @@ class Btrfs(Utils):
         subvolid = self._get_btrfs_value('%s/%s' % (SYSROOT, self.next_rootfs), 'Subvolume ID')
         argv = 'subvolume set-default %s %s' % (subvolid, SYSROOT)
         if not self._btrfs(argv):
+            os.system('cp -f %s/%s/boot/* /boot/' % (SYSROOT, FACTORY_SNAPSHOT))
             return True
         else:
             self.message += "Cannot set default mount subvolume to %s" % self.next_rootfs


### PR DESCRIPTION
To get a network mac address as the system id which is
used by smartpm to identify a specific rpm upgrading
connection.

Signed-off-by: fli <fupan.li@windriver.com>