### PR TITLE
overc-system-agent: remove the packages information after the contain…

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
@@ -371,6 +371,7 @@ rpm_upgrade() {
 	runcmd_in_container $container "umount /var/lib/rpm"
 	runcmd_in_container $container "cp -r $tempdir/rpm /var/lib/"
 	runcmd_in_container $container "rm -rf $tempdir"
+	runcmd_in_container $container "sed -i /^CUBEUPDATE:/d /etc/motd"
 }
 
 delete_container() {


### PR DESCRIPTION
…er upgrade

When the "cube-update" service check some new packages information from
the rpm repo, it will keep the newer packages number in the /etc/motd to
note user to upgrade the system. After user execute the system upgrade
command, these updating packages information should be removed from the
/etc/motd. Or it will confuse user whether the system has upgraded these
new packages successfully.

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>