### PR TITLE
images: allow user to overwrite IMAGE_FSTYPES

### DIFF
--- a/meta-cube/recipes-core/images/cube-builder_0.3.bb
+++ b/meta-cube/recipes-core/images/cube-builder_0.3.bb
@@ -24,7 +24,8 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 
 IMAGE_FEATURES += "package-management doc-pkgs"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 INITRD = "True"
 INITRAMFS_IMAGE = "cube-builder-initramfs"

--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -10,7 +10,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 IMAGE_FEATURES += "package-management doc-pkgs x11-base"
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 PACKAGE_EXCLUDE = "busybox*"
 # Exclude documention packages, which can be installed later

--- a/meta-cube/recipes-core/images/cube-dom0.bb
+++ b/meta-cube/recipes-core/images/cube-dom0.bb
@@ -36,7 +36,8 @@ IMAGE_INSTALL += "${DOM0_MAIN_PKGS} \
 
 IMAGE_FEATURES += "package-management doc-pkgs"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 TARGETNAME ?= "cube-dom0"
 

--- a/meta-cube/recipes-core/images/cube-dom1_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-dom1_0.1.bb
@@ -24,7 +24,8 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 
 IMAGE_FEATURES += "package-management doc-pkgs"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 inherit core-image
 inherit builder-base

--- a/meta-cube/recipes-core/images/cube-essential_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.1.bb
@@ -32,7 +32,8 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 
 IMAGE_FEATURES += "package-management"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 TARGETNAME ?= "cube-essential"
 

--- a/meta-cube/recipes-core/images/cube-graphical-builder_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-graphical-builder_0.2.bb
@@ -45,7 +45,8 @@ ALTERNATIVE_PRIORITY_xfce4-session[x-session-manager] = "60"
 IMAGE_FEATURES += "x11-base"
 IMAGE_FEATURES += "package-management doc-pkgs"
 
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 inherit core-image
 inherit builder-base

--- a/meta-cube/recipes-core/images/cube-server_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-server_0.1.bb
@@ -13,7 +13,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d
 CUBE_DOM_SERVER_EXTRA_INSTALL ?= ""
 
 IMAGE_FEATURES += "package-management doc-pkgs"
-IMAGE_FSTYPES = "tar.bz2"
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
 
 PACKAGE_EXCLUDE = "busybox*"
 # Exclude documention packages, which can be installed later


### PR DESCRIPTION
There is no reason to strictly enforce the use of one IMAGE_FSTYPE and
this is something which is often customized in local.conf (we even
include this in our local.conf.sample), so change this to an early
assignment allowing a user to set this how they wish in their
local.conf or elsewhere.

Since the machine definition or other configs may attempt to enable
the 'live' IMAGE_FSTYPE and this brings in busybox via
VIRTUAL-RUNTIME_base-utils and VIRTUAL-RUNTIME_base-utils-hwclock,
which we currently don't implement a workaround for, we explicitly
remove the 'live' IMAGE_FSTYPE to prevent its use.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>