### PR TITLE
samba: fix installed-vs-shipped QA issue

### DIFF
--- a/meta-cube/recipes-core/initrdscripts/files/init-server.sh
+++ b/meta-cube/recipes-core/initrdscripts/files/init-server.sh
@@ -88,7 +88,7 @@ sleep ${ROOT_DELAY}
 
 echo "Waiting for root device to be ready..."
 while [ 1 ] ; do
-    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT && break
+    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT 2>/dev/null && break
     sleep 0.1
 done
 


### PR DESCRIPTION
The upstream has updated samba which leads to the following QA issue:

ERROR: samba-4.4.5-r0 do_package: QA Issue: samba: Files/directories
were installed but not shipped in any package:
  /usr/lib64/security/pam_winbind.so
Please set FILES such that these items are packaged. Alternatively if
they are unneeded, avoid installing them or delete them within
do_install.
samba: 1 installed and not shipped files. [installed-vs-shipped]
ERROR: samba-4.4.5-r0 do_package: Fatal QA errors found, failing task.
ERROR: samba-4.4.5-r0 do_package: Function failed: do_package

Install the so to the ${PN} named package.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>