### PR TITLE
hashicorp-*: fixup host_user_contaminated QA issues

### DIFF
--- a/meta-cube/recipes-devtools/go/hashicorp-errwrap_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-errwrap_git.bb
@@ -18,7 +18,7 @@ SYSROOT_PREPROCESS_FUNCS += "hashicorp_errwrap_sysroot_preprocess"
 
 hashicorp_errwrap_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-cleanhttp_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-cleanhttp_git.bb
@@ -11,14 +11,14 @@ S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_cleanhttp_sysroot_preprocess"
 
 hashicorp_cleanhttp_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-immutable-radix_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-immutable-radix_git.bb
@@ -13,14 +13,14 @@ DEPENDS += " golang-lru"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_radix_sysroot_preprocess"
 
 hashicorp_radix_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-memdb_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-memdb_git.bb
@@ -13,14 +13,14 @@ DEPENDS += " hashicorp-go-immutable-radix"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_memdb_sysroot_preprocess"
 
 hashicorp_memdb_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-net_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-net_git.bb
@@ -11,14 +11,14 @@ S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_go_net_sysroot_preprocess"
 
 hashicorp_go_net_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-reap_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-reap_git.bb
@@ -11,14 +11,14 @@ S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_reap_sysroot_preprocess"
 
 hashicorp_reap_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-go-uuid_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-go-uuid_git.bb
@@ -11,14 +11,14 @@ S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_uuid_sysroot_preprocess"
 
 hashicorp_uuid_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"

--- a/meta-cube/recipes-devtools/go/hashicorp-hil_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-hil_git.bb
@@ -11,14 +11,14 @@ S = "${WORKDIR}/git"
 
 do_install() {
     install -d ${D}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
+    cp -a --no-preserve=ownership ${S}/* ${D}${prefix}/local/go/src/${PKG_NAME}/
 }
 
 SYSROOT_PREPROCESS_FUNCS += "hashicorp_hil_sysroot_preprocess"
 
 hashicorp_hil_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
-    cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
+    cp -a --no-preserve=ownership ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"


### PR DESCRIPTION
We want pseudo to handle setting file and directory ownership, this is
not possible when using things like 'cp -a', resulting in errors such
as:

 <file> is owned by uid 1001, which is the same as the user running
      bitbake. This may be due to host contamination

(note: "host-user-contaminated" must be enabled in WARN_QA to see these)

By using additional options to 'cp' we can avoid this and the QA
issues and any negative side effects which the QA check is warning
about go away.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>