### PR TITLE
overc-system-agent:Restore an overlay-ed directory

### DIFF
--- a/meta-cube/recipes-core/lxc/files/lxc-overlayclean
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayclean
@@ -1,0 +1,6 @@
+#!/bin/sh -
+
+# /usr/lib64/lxc/lxc/lxc-overlayclean
+# Final cleanup for lxc overlay related services
+
+cp /etc/lxc/lxc-overlayrestore.bak /etc/lxc/lxc-overlayrestore

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
@@ -1,0 +1,4 @@
+#!/bin/sh -
+
+# /usr/lib64/lxc/lxc/lxc-overlayrestore
+# Rebuild a overlay-ed directory

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayrestore.bak
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayrestore.bak
@@ -1,0 +1,4 @@
+#!/bin/sh -
+
+# /usr/lib64/lxc/lxc/lxc-overlayrestore
+# Rebuild a overlay-ed directory

--- a/meta-cube/recipes-core/lxc/files/overlaycreate
+++ b/meta-cube/recipes-core/lxc/files/overlaycreate
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+scandir()
+{
+# Search each entry in base_path, delete same file in target_path.
+for entry in $(ls $1 -A); do
+    if [ -e "$2/${entry}" ] || [ -L "$2/${entry}" ]; then
+        if [ -d "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+            [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Only enter dir when both $1/entry & $2/entry are directory
+            scandir "$1/$entry" "$2/$entry" "$3/$entry"
+        elif [ -f "$2/${entry}" ] && [ ! -L "$2/${entry}" ] && \
+              [ -f "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are regular file
+            rm "$2/${entry}"
+        elif [ -L "$2/${entry}" ] && [ -L "$1/${entry}" ]; then
+            # Delete when both $1/entry & $2/entry are sympol-link
+            rm "$2/${entry}"
+        fi
+        # Ignore other conditions
+    elif [ ! -e "$3/${entry}" ]; then
+        # Create a mask file in mask_path
+	pathname=`dirname $3/${entry}`
+	if [ ! -d ${pathname} ]; then
+		mkdir -p ${pathname}
+	fi
+	mknod $3/${entry} c 0 0 --mode=000
+    fi
+done;
+# Remove empty diretory in target_path
+if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
+    rmdir "$2"
+fi
+}
+
+# $1 container name
+# $2 direcotry name
+# $3 source containers
+cn=$1
+dir=$2
+
+LXCBASE=/var/lib/lxc
+
+# Create mask over dir
+mkdir ${LXCBASE}/${cn}${dir}_mask
+mkdir ${LXCBASE}/${cn}${dir}_over
+
+fstab_entry="overlay ${LXCBASE}/${cn}/rootfs${dir} overlay lowerdir=${LXCBASE}/${cn}${dir}_mask"
+
+cns=`echo $3|sed "s/,/ /g"`
+for cn0 in $cns; do
+# locate dir
+	if [ ${cn0} == "essential" ]; then
+		low=${dir}
+	else
+		low=${LXCBASE}/${cn}/rootfs${dir}_temp
+		if [ ! -d ${low} ]; then
+			low=${LXCBASE}/${cn}/rootfs${dir}
+		fi
+	fi
+# scan dir
+	if [ -d ${low} ]; then
+		#scandir ${low} ${LXCBASE}/${cn}/rootfs${dir} ${LXCBASE}/${cn}${dir}_mask
+		fstab_entry="${fstab_entry}:${low}"
+	fi
+done;
+
+if [ -d ${LXCBASE}/${cn}/rootfs${dir} ]; then
+	mv ${LXCBASE}/${cn}/rootfs${dir} ${LXCBASE}/${cn}/rootfs${dir}_temp
+else
+	mkdir ${LXCBASE}/${cn}/rootfs${dir}_temp
+fi
+mkdir ${LXCBASE}/${cn}/rootfs${dir}
+fstab_entry="${fstab_entry},upperdir=${LXCBASE}/${cn}/rootfs${dir}_temp,workdir=${LXCBASE}/${cn}${dir}_over 0       0"
+
+#Hack fstab, remove line in fstab of this container, and update referce in other containers
+for cn0 in $(lxc-ls); do
+	if [ ${cn0} = ${cn} ]; then
+		echo ${fstab_entry} >> ${LXCBASE}/${cn0}/fstab
+	else
+		sed -i "s#${LXCBASE}/${cn}/rootfs${dir}:#${LXCBASE}/${cn}/rootfs${dir}_temp:#" ${LXCBASE}/${cn0}/fstab
+		sed -i "s#${LXCBASE}/${cn}/rootfs${dir},#${LXCBASE}/${cn}/rootfs${dir}_temp,#" ${LXCBASE}/${cn0}/fstab
+	fi
+done;

--- a/meta-cube/recipes-core/lxc/files/overlayrestore
+++ b/meta-cube/recipes-core/lxc/files/overlayrestore
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+restore()
+{
+for entry in $(ls $1 -A); do
+	if [ -d "$3/${entry}" ] && [ ! -L "$3/${entry}" ] && \
+	    [ -d "$1/${entry}" ] && [ ! -L "$1/${entry}" ]; then
+		restore "$1/$entry" "$2/$entry" "$3/$entry"
+	elif [ ! -c "$3/${entry}" ]; then
+		cp -a -n "$1/${entry}" "$2/"
+        fi
+done;
+}
+
+# $1 container name
+# $2 direcotry name
+
+
+# Open fstab for conatainer
+
+cn=$1
+oldir=$2
+
+LXCBASE=/var/lib/lxc
+
+dirmask=$LXCBASE/${cn}${oldir}_mask
+
+options=`cat ${LXCBASE}/${cn}/fstab|awk '{if (( $1=="'overlay'" ) && ( $2=="'${LXCBASE}/${cn}/rootfs${oldir}'" ))print $4}'`
+for option in $options; do
+	dirs=`echo ${option}|sed 's/,/\n/g'`
+	for dir in $dirs; do
+		dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'lowerdir'" )print $2}'`
+		if [ ! -z ${dirout} ]; then
+			dirlow=$dirout
+		fi
+		dirout=`echo ${dir}|awk -F "=" '{if ( $1=="'upperdir'" )print $2}'`
+		if [ ! -z ${dirout} ]; then
+			dirup=$dirout
+		fi
+	done;
+	dirlows=`echo ${dirlow}|sed 's/:/\n/g'`
+	for low in ${dirlows}; do
+		if [ ${low} = ${dirmask} ]; then # Skip mask
+			continue
+		fi
+		echo "restore ${LXCBASE}/${cn}/rootfs${oldir} from ${low} ..."
+		restore ${low} ${dirup} ${dirmask}
+	done;
+	rm -rf ${dirmask}
+	rm -rf ${LXCBASE}/${cn}${oldir}_over
+	rm -rf ${LXCBASE}/${cn}/rootfs${oldir}
+	mv ${LXCBASE}/${cn}/rootfs${oldir}_temp ${LXCBASE}/${cn}/rootfs${oldir}
+done;
+
+#Hack fstab, remove line in fstab of this container, and update referce in other containers
+for cn0 in $(lxc-ls); do
+	if [ ${cn0} = ${cn} ]; then
+		sed -i "\@^overlay *${LXCBASE}/${cn}/rootfs${oldir}@d" ${LXCBASE}/${cn0}/fstab
+	else
+		sed -i "s#${LXCBASE}/${cn}/rootfs${oldir}_temp#${LXCBASE}/${cn}/rootfs${oldir}#" ${LXCBASE}/${cn0}/fstab
+	fi
+done;

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -16,6 +16,7 @@ SRC_URI += " \
     file://lxc-overlayrestore.bak \
     file://lxc-overlayclean \
     file://overlayrestore \
+    file://overlaycreate \
     file://silence_no_escape_lxc-console.patch \
     file://read-write-file-handles-after-EPOLLHUP.patch \
     file://lxc-start-config-Add-lxc.uncontain-to-access-CAP_ADM.patch \
@@ -50,4 +51,5 @@ ExecStartPre=/etc/lxc/lxc-overlayrestore\nExecStartPre=/etc/lxc/lxc-overlayclean
 	install -m 755 ${WORKDIR}/lxc-overlayrestore.bak ${D}/etc/lxc/lxc-overlayrestore.bak
 	install -m 755 ${WORKDIR}/lxc-overlayclean ${D}/etc/lxc/lxc-overlayclean
 	install -m 755 ${WORKDIR}/overlayrestore ${D}/etc/lxc/overlayrestore
+	install -m 755 ${WORKDIR}/overlaycreate ${D}/etc/lxc/overlaycreate
 }

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -12,6 +12,10 @@ SRC_URI += " \
     file://ovs-up \
     file://ovs-down \
     file://lxc-overlayscan \
+    file://lxc-overlayrestore \
+    file://lxc-overlayrestore.bak \
+    file://lxc-overlayclean \
+    file://overlayrestore \
     file://silence_no_escape_lxc-console.patch \
     file://read-write-file-handles-after-EPOLLHUP.patch \
     file://lxc-start-config-Add-lxc.uncontain-to-access-CAP_ADM.patch \
@@ -23,6 +27,9 @@ do_install_append(){
 
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
 	sed -i 's/\(After=.*$\)/\1 openvswitch-nonetwork.service/' ${D}${systemd_unitdir}/system/lxc.service
+	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
+ExecStartPre=/etc/lxc/lxc-overlayrestore\nExecStartPre=/etc/lxc/lxc-overlayclean
+}' ${D}${systemd_unitdir}/system/lxc.service
 
 	# disable the dmesg output on the console when booting the containers,
 	# and this will make the system's boot console clean and reduce the boottime.
@@ -39,4 +46,8 @@ do_install_append(){
 
 	# add script to scan dir mount with overlay to delete duplicate file
 	install -m 755 ${WORKDIR}/lxc-overlayscan ${D}/etc/lxc/lxc-overlayscan
+	install -m 755 ${WORKDIR}/lxc-overlayrestore ${D}/etc/lxc/lxc-overlayrestore
+	install -m 755 ${WORKDIR}/lxc-overlayrestore.bak ${D}/etc/lxc/lxc-overlayrestore.bak
+	install -m 755 ${WORKDIR}/lxc-overlayclean ${D}/etc/lxc/lxc-overlayclean
+	install -m 755 ${WORKDIR}/overlayrestore ${D}/etc/lxc/overlayrestore
 }

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -280,4 +280,23 @@ class Overc(object):
     def _container_delete_snapshots(self, container, template):
         self.retval = self.container.delete_snapshots(container, template)
         self.message = self.container.message
+    def container_overlay(self):
+        # Parser commnand, create or restore
+        if self.args.ollist:
+	    self._container_overlay_list(self.args.name, self.args.template)
+        elif self.args.olstop:
+            self._container_overlay_stop(self.args.name, self.args.template, self.args.oldir)
+        else :
+            self._container_overlay_create(self.args.name, self.args.template, self.args.oldir, self.args.olsource)
+    def _container_overlay_list(self, container, template):
+	# List overlay dir in container
+        print "overlayed directories in %s including:" % container
+        print ",".join(self.container.get_overlay(container))
+
+    def _container_overlay_create(self, container, template, dirs, source):
+        # Create overlay dir in container
+        self.retval = self.container.overlay_create(container, template, dirs, source)
+    def _container_overlay_stop(self, container, template, dirs):
+        # Restore overlay-ed dir
+        self.retval = self.container.overlay_stop(container, template, dirs)
 

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
@@ -168,6 +168,15 @@ if __name__ == '__main__':
     c_delete_snapshots.add_argument('name', help="name of container")
     c_delete_snapshots.add_argument('template', help="template of container")
 
+    c_overlay = container_subparser.add_parser("overlay", help=_("manager overlay dir in container"))
+    c_overlay.set_defaults(func=overc.container_overlay)
+    c_overlay.add_argument('name', help="name of container")
+    c_overlay.add_argument('template', help="template of container")
+    c_overlay.add_argument('--stop', dest="olstop", action="store_true", help=_("stop overlay"))
+    c_overlay.add_argument('--dir', dest="oldir", help=_("overlay directories"))
+    c_overlay.add_argument('--source', dest="olsource", help=_("overlay source"))
+    c_overlay.add_argument('--list', dest="ollist", action="store_true", help=_("list directories with overlay"))
+
     try:
         args = parser.parse_args()
         overc.set_args(args)


### PR DESCRIPTION
Add overlay command under overc container subcommand:
1.overc container overlay --list [container] [template]
This command lists all directories in container with overlayfs.

2.overc container overlay --stop [container] [template] --dir [dir1,dir2...]
This command restores directories in container with overlayfs into original state.

This command insert a overlay rebuild request into lxc.service. When system rebooting, before lxc lanuch containers. It will rebuild the directory as user requested.
