### PR TITLE
initramfs: eliminate error messages when checking rootfs

### DIFF
--- a/meta-cube/recipes-core/initrdscripts/files/init-server.sh
+++ b/meta-cube/recipes-core/initrdscripts/files/init-server.sh
@@ -88,7 +88,7 @@ sleep ${ROOT_DELAY}
 
 echo "Waiting for root device to be ready..."
 while [ 1 ] ; do
-    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT && break
+    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT 2>/dev/null && break
     sleep 0.1
 done
 


### PR DESCRIPTION
Currently when detecting rootfs, error messages about not finding label
will print on the screen which is confusing.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>