### PR TITLE
initramfs: eliminate error messages when checking rootfs

### DIFF
--- a/meta-cube/recipes-core/initrdscripts/files/init-server.sh
+++ b/meta-cube/recipes-core/initrdscripts/files/init-server.sh
@@ -88,7 +88,7 @@ sleep ${ROOT_DELAY}
 
 echo "Waiting for root device to be ready..."
 while [ 1 ] ; do
-    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT && break
+    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT 2>/dev/null && break
     sleep 0.1
 done
 


### PR DESCRIPTION
While waiting for the rootfs device to be ready, we use mount command
to test the status. Somehow the mount command will output error
messages before the rootfs device ready. So we hide these error
messages while waiting and let user know the final result after the
waiting procedure.

Signed-off-by: Feng Mu <Feng.Mu@windriver.com>