### PR TITLE
overc-system-agent: delete the container's history snapshots by default

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -88,7 +88,7 @@ class Container(object):
         dirlist=self.get_overlay(name)
         return len(dirlist)
 
-    def upgrade(self, name, template, rpm_upgrade=True, image_upgrade=False):
+    def upgrade(self, name, template, rpm_upgrade=True, image_upgrade=False, skip_del=False):
         if image_upgrade and not rpm_upgrade:
             retval = self.update(template)
             if retval is 0:
@@ -98,7 +98,10 @@ class Container(object):
                 msg2 = self.message
                 self.message = msg1 + "\n" + msg2
         else:
-            args = "-r -n %s" % name
+            if skip_del:
+                args = "-r -n %s -f" % name
+            else:
+                args = "-r -n %s" % name 
             retval = self.run_script(template, args)
 
         if retval is 0:

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -53,9 +53,9 @@ class Overc(object):
             self.command = None
 
     def system_upgrade(self):
-        self._system_upgrade(self.args.template, self.args.reboot, self.args.force, self.args.skipscan)
+        self._system_upgrade(self.args.template, self.args.reboot, self.args.force, self.args.skipscan, self.args.skip_del)
 
-    def _system_upgrade(self, template, reboot, force, skipscan):
+    def _system_upgrade(self, template, reboot, force, skipscan, skip_del):
 	print "skipscan %d" % skipscan
         containers = self.container.get_container(template)
         overlay_flag = 0
@@ -66,7 +66,7 @@ class Overc(object):
 	        for dist in DIST.split():
 	            if dist in self.container.get_issue(cn, template).split():
                         print "Updating container %s" % cn
-                        self._container_upgrade(cn, template) #by now only rpm upgrade support
+                        self._container_upgrade(cn, template, True, False, skip_del) #by now only rpm upgrade support
                         if self.retval is not 0:
                             print "*** Failed to upgrade container %s" % cn
                             print "*** Abort the system upgrade action"
@@ -268,10 +268,10 @@ class Overc(object):
             print "This container can only be upgraded via a system upgrade"
             self.retval = 0
         else:
-            self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image)
+            self._container_upgrade(self.args.name, self.args.template, self.args.rpm, self.args.image, self.args.skip_del)
         sys.exit(self.retval)
-    def _container_upgrade(self, container, template, rpm=True, image=False):
-        self.retval = self.container.upgrade(container, template, rpm, image)
+    def _container_upgrade(self, container, template, rpm=True, image=False, skip_del=False):
+        self.retval = self.container.upgrade(container, template, rpm, image, skip_del)
         self.message = self.container.message
 
     def container_delete_snapshots(self):

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
@@ -46,8 +46,12 @@ Usage: $0 [OPTION] ...
 	delete container
 
 	-f: force
-  -r -n <container name>
+  -r -n <container name> [-f]
         update container using rpm packages
+	
+	-f: force not to delete all of the container's history snapshots
+	    before create a latest snapshot of this container, otherwise,
+	    it will delete all of the container's history snapshots by default.
   -p -n <container name>
         creates a snapshot of the container
   -D -n <container name>
@@ -345,6 +349,10 @@ rpm_upgrade() {
 	runcmd_in_container $container "smart newer"
 	if [ ! $? -eq 0 ]; then
 		return 0
+	fi
+
+	if [ ! $force -eq 1 ]; then
+		delete_snapshots $container
 	fi
 
 	c_raw_size=`du -hs /var/lib/lxc/${container}/rootfs | awk '{print $1}'`

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
@@ -67,6 +67,9 @@ if __name__ == '__main__':
 	s_upgradep.add_argument("-s", "--skipscan", dest="skipscan",
 				action="store_true",
 				help=_("if an upgrade involve container use overlayfs, skip duplicate file scan after deployment"))
+	s_upgradep.add_argument("-S", "--skipdel", dest="skip_del",
+				action="store_true",
+				help=_("don't delete all of the container's history snapshots before upgrading it"))
 
         s_roolback = system_subparse.add_parser("rollback", help=_("switch to the top of the history rollback list, including host and containers"))
         s_roolback.set_defaults(func=overc.system_rollback)
@@ -140,6 +143,9 @@ if __name__ == '__main__':
     c_upgrade.add_argument('template', help="template of container")
     c_upgrade.add_argument("-r", "--rpm", dest="rpm", action="store_true", help=_("Upgrade container using rpm feeds"))
     c_upgrade.add_argument("-i", "--image", dest="image", action="store_true", help=_("Upgrade container using images"))
+    c_upgrade.add_argument("-S", "--skipdel", dest="skip_del",
+                           action="store_true",
+                           help=_("don't delete all of the container's history snapshots before upgrading it"))
 
     c_activate = container_subparser.add_parser("activate", help=_("activate container"))
     c_activate.set_defaults(func=overc.container_activate)


### PR DESCRIPTION
When do container upgrading, delete all of this container's history
snapshosts before create a latest snapshot by default. If don't want
to delete them, pass a parameter of "-S".

Signed-off-by: fli <fupan.li@windriver.com>