### PR TITLE
OverC: allow -essential to be read-only

### DIFF
--- a/meta-cube/recipes-core/images/cube-essential_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.1.bb
@@ -42,5 +42,60 @@ INITRAMFS_IMAGE = "cube-builder-initramfs"
 # We want it separate, and not bundled with the kernel by default.
 INITRAMFS_IMAGE_BUNDLE ?= ""
 
+IMAGE_FEATURES += "read-only-rootfs"
+
 inherit core-image
 inherit builder-base
+
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs", "read_only_essential; ", "",d)}'
+
+read_only_essential () {
+    echo "none	/etc/openvswitch	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    mkdir -p ${IMAGE_ROOTFS}/opt/container
+    echo "none	/opt/container	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    echo "none	/var/lib/misc	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    if [ -d ${IMAGE_ROOTFS}/etc/puppet ]; then
+        mkdir -p ${IMAGE_ROOTFS}/var/lib/puppet
+        mkdir -p ${IMAGE_ROOTFS}/var/log/puppet
+        echo "none	/var/lib/puppet	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+        echo "none	/var/log/puppet	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/hosts ]; then
+        mv ${IMAGE_ROOTFS}/etc/hosts ${IMAGE_ROOTFS}/etc/hosts0
+        ln -s ../run/systemd/resolve/hosts ${IMAGE_ROOTFS}/etc/hosts
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/dnsmasq.conf ]; then
+        mv ${IMAGE_ROOTFS}/etc/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf0
+        ln -s ../run/systemd/resolve/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf
+    fi
+    ln -s ../run/systemd/resolve/resolv.conf ${IMAGE_ROOTFS}/etc/resolv.conf
+    if [ -e ${IMAGE_ROOTFS}/etc/system-id ]; then
+        rm ${IMAGE_ROOTFS}/etc/system-id -f
+    fi
+    ln -s ../run/systemd/resolve/system-id ${IMAGE_ROOTFS}/etc/system-id
+    if [ -e ${IMAGE_ROOTFS}/lib/systemd/system/cube-cmd-server.service ]; then
+	sed -i '/^\[Service\]/a\\ExecStartPre=/bin/sh -c "mkdir -p  /opt/container/dom0 /opt/container/cube-desktop /opt/container/all /opt/container/local"' ${IMAGE_ROOTFS}/lib/systemd/system/cube-cmd-server.service
+    fi
+    if [ -e ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service ]; then
+	sed -i '/ExecStart/d' ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service
+	sed -i '/^\[Service\]/a\\ \
+ExecStartPre=/bin/sh -c "cp /etc/hosts0 /run/systemd/resolve/hosts" \
+ExecStartPre=/bin/sh -c "cp /etc/dnsmasq.conf0 /run/systemd/resolve/dnsmasq.conf" \
+ExecStart=/bin/sh -c "/usr/bin/puppet apply /etc/puppet/manifests/site.pp" \
+' ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/systemd/network/20-wired.network ]; then
+	rm -f ${IMAGE_ROOTFS}/etc/systemd/network/20-wired.network
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/files/25-br-int.network.essential ]; then
+	cp ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/files/25-br-int.network.essential ${IMAGE_ROOTFS}/etc/systemd/network/25-br-int.network
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp ]; then
+        sed -i '/^ *file.*25-br-int.network.essential/,/}/d' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+        sed -i '/25-br-int.network.essential/d' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+        sed -i '/^ *file.*20-wired.network.essential/,/}/d' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+	sed -i 's/ \/etc\/resolv.conf/ \/run\/systemd\/resolve\/resolv.conf/g' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+	sed -i 's/"\/etc\/resolv.conf/"\/run\/systemd\/resolve\/resolv.conf/g' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+        sed -i '/^ *file_line.*disable-network-prime-setup/,/}/d' ${IMAGE_ROOTFS}/etc/puppet/modules/network_prime/manifests/init.pp
+    fi
+}

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayclean
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayclean
@@ -1,5 +1,0 @@
-#!/bin/sh -
-
-# Remove all served request from lxc-overlayrestore
-
-sed -i "\@/etc/lxc/overlay@d" /etc/lxc/lxc-overlayrestore

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
@@ -2,3 +2,9 @@
 
 # Rebuild an overlay-ed directory
 # Or turn an overlay-ed directroy into orignal state
+
+if [ -e /var/lib/lxc/overlayrestore ]; then
+	chmod +x /var/lib/lxc/overlayrestore
+	/var/lib/lxc/overlayrestore
+	rm -f /var/lib/lxc/overlayrestore
+fi

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayscan
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayscan
@@ -38,6 +38,11 @@ if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
 fi
 }
 
+#0.Check flag file
+if [ ! -e /var/lib/lxc/need_scan_duplicate ]; then
+	exit 0
+fi
+
 # 1.List all containers
 for cn in $(lxc-ls); do
 # 2.Open /var/lib/lxc/$container/fstab, list all overlay mount entry
@@ -63,4 +68,4 @@ for cn in $(lxc-ls); do
 done;
 
 # Remove service from lxc.service
-sed -i "/lxc-overlayscan/d" /lib/systemd/system/lxc.service
+rm -f /var/lib/lxc/need_scan_duplicate

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -28,7 +28,7 @@ do_install_append(){
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
 	sed -i 's/\(After=.*$\)/\1 openvswitch-nonetwork.service/' ${D}${systemd_unitdir}/system/lxc.service
 	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
-ExecStartPre=/etc/lxc/lxc-overlayrestore\nExecStartPre=/etc/lxc/lxc-overlayclean
+ExecStartPre=/etc/lxc/lxc-overlayscan\nExecStartPre=/etc/lxc/lxc-overlayrestore
 }' ${D}${systemd_unitdir}/system/lxc.service
 
 	# disable the dmesg output on the console when booting the containers,

--- a/meta-cube/recipes-support/overc-conftools/overc-conftools_1.0.bb
+++ b/meta-cube/recipes-support/overc-conftools/overc-conftools_1.0.bb
@@ -31,6 +31,7 @@ SRC_URI = " \
     file://source/network_prime/templates/network_prime.sh.erb \
     file://source/network_prime/templates/network_prime_port_forward.sh.erb \
     file://source/system/systemid-set.sh \
+    file://source/essential_rw.sh \
 "
 
 S = "${WORKDIR}"
@@ -75,6 +76,9 @@ do_install() {
     # systemd services
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/source/overc-conftools.service ${D}${systemd_unitdir}/system/
+
+    install -d ${D}/${sysconfdir}/profile.d/
+    install -m 0644 ${WORKDIR}/source/essential_rw.sh ${D}/${sysconfdir}/profile.d/
 }
 
 RDEPENDS_${PN} += " \

--- a/meta-cube/recipes-support/overc-conftools/source/essential_rw.sh
+++ b/meta-cube/recipes-support/overc-conftools/source/essential_rw.sh
@@ -1,0 +1,26 @@
+rw_test=`mount |grep " / "|grep rw`
+
+if [ -z "$rw_test" ]; then
+	if read -t 5 -p "Essential is read-only, if you need login as read-write, please enter \"yes\":" rw_allow
+	then
+		if [ "$rw_allow" == "yes" ]; then
+			mount / -o remount,rw
+		fi
+	fi
+else
+	if read -t 5 -p "Essential is read-write, if you need login as read-only, please enter \"yes\":" rw_allow
+	then
+		if [ "$rw_allow" == "yes" ]; then
+			umount /
+		fi
+	fi
+fi
+echo
+rw_test=`mount |grep " / "|grep rw`
+
+if [ ! -z "$rw_test" ]; then
+	echo "Warning, Essential rootfs is in read-write, all modification on essential will be recorded."
+	echo "To return read-only, please issue \"umount /\" or reboot system."
+else
+	echo "Essential is in read-only."
+fi

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -224,7 +224,7 @@ class Container(object):
 		    print "%s:already an overlay-ed dir in container" % (oldir)
 	            return -1
         # Insert request into lxc.service
-        lxcfile = '%s/etc/lxc/lxc-overlayrestore' % (ROOTMOUNT)
+        lxcfile = '%s/overlayrestore' % (CONTAINER_MOUNT)
         lxc = open(lxcfile, 'a+')
         lines=lxc.readlines()
         found = 0

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -79,21 +79,9 @@ class Overc(object):
         rc = self._host_upgrade(0, force)
 
         if ((overlay_flag == 1) and (skipscan == 0) and (rc == 1)):
-            # Enable lxc-overlay service in essential
-            lxcfile = '%s/%s/lib/systemd/system/lxc.service' % (SYSROOT, self.agency.next_rootfs)
-            lxc = open(lxcfile, 'r')
-            lines = lxc.readlines()
-            lxc.close()
-            for line in lines:
-                if line.find("lxc_overlay") != -1:
-                    sys.exit(self.retval)
-            for line in lines:
-                if line.find("ExecStart") != -1:
-                    index = lines.index(line)
-                    break
-            lines.insert(index, "ExecStartPre=/etc/lxc/lxc-overlayscan\n")
-            lxc = open(lxcfile, 'w')
-            lxc.writelines(lines)
+            # Enable lxc-overlay service in essential by create a flagfile in CONTAINER_MOUNT
+            lxcfile = '%s/need_scan_duplicate' % (CONTAINER_MOUNT)
+            lxc = open(lxcfile, 'w+')
             lxc.close()
 
         if ((rc == 1) and (reboot != 0)):


### PR DESCRIPTION
This pull-request contain 3 patch:
1.patch 1 create a read-only essential by adding read-only-rootfs in IMAGE_FEATURES. Also created new mount entry & temporary file to make overc required service working on readonly rootfs, including openvswitch, puppet, cube-cmd-serive.

2.patch 2 add a script in /etc/profile.d to generate Warning message & allow user change read/write attribute when login to essential.

3.patch 3 update lxc to allow overlayfs related service working on readonly essential.

Testing including:
1.booting: some systemd service still failed, but it won't affect overc running.
2.cube-cmd,cube-console
3.network