### PR TITLE
consul: drop QA warning about ldflags/GNU HASH

### DIFF
--- a/meta-cube/recipes-connectivity/consul/consul_git.bb
+++ b/meta-cube/recipes-connectivity/consul/consul_git.bb
@@ -48,8 +48,7 @@ CCACHE = ""
 
 inherit systemd golang
 
-ERROR_QA_remove = "ldflags"
-WARN_QA_append = " ldflags"
+INSANE_SKIP_${PN} += "ldflags"
 
 SYSTEMD_SERVICE_${PN} = "consul.service"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"


### PR DESCRIPTION
Fixes #50

Previously we made this QA error a QA warning such that we would be
reminded to look more closely at this one day. Having had some time
this has now been looked into and the following summarizes the
investigation.

Unlike packages like 'bolt' and other GO applicaitons consul is not
linked statically. Like these other GO applications it is being linked
with GO's internal linker which, unlike the external/'system' linker, does not
have support for GNU HASH. The combination of these two things result
in it failing the --hash-style check and producing the QA Warning:

WARNING: consul-git-r0 do_package_qa: QA Issue: No GNU_HASH in the elf binary:
  '.../tmp/work/core2-64-overc-linux/consul/git-r0/packages-split/consul/usr/bin/consul' [ldflags]

We could work around this by using the external linker but this has
several downsides such as portability and thread handling ... as
discussed here: https://github.com/golang/go/issues/5238

Modifying the golang.bbclass I am able to demonstrate that using:

go install -ldflags '-linkmode external' ${PKG_NAME}

does satisfy the QA check but when weighing the benefits of using the
GNU HASH vs the known and unknown downsides of not using the GO
internal linker I believe we are better off using the GO internal
linker.

An alternative might be to link consul statically, but my reading
seems to indicate that this could also come with its own
challenges. So the best solution at this time is to simply ignore the
fact that we are not using GNU HASH, giving up a few known benefits
but avoiding introducing unknown complications.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>