### PR TITLE
[v3]make essential as read-only rootfs

### DIFF
--- a/README.install
+++ b/README.install
@@ -55,6 +55,16 @@ being build and assembled.
 Once the build (or download) completes, the build artifacts must be assembled
 into an installer image (see the following sections).
 
+By default, rootfs for cube-essential is in read-only mode, changes on
+rootfs will lead failure or lost after system reboot. User may change
+read/write attribute of rootfs when system running after login to
+cube-essenial as root user.
+
+To build a read-write rootfs for cube-essential, please add following line in
+local.conf before building cube-essential:
+
+ OVERC_ESSENTIAL_MODE = "read-write"
+
 OverC installer
 ---------------
 

--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -56,3 +56,8 @@ RDEPENDS_packagegroup-core-full-cmdline-sys-services_remove = "lighttpd"
 SYSVINIT_SCRIPTS_remove_pn-packagegroup-core-boot = "busybox-hwclock"
 
 ####  end busybox removal ####
+
+# OVERC_ESSENTIAL_MODE describes the read/write mode of essential rootfs in OverC. By
+# default, essential rootfs is read-only. To change it to read-write, please update
+# value to "read-write", then rebuild essential rootfs.
+OVERC_ESSENTIAL_MODE = "read-only"

--- a/meta-cube/recipes-core/images/cube-essential_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.1.bb
@@ -42,5 +42,74 @@ INITRAMFS_IMAGE = "cube-builder-initramfs"
 # We want it separate, and not bundled with the kernel by default.
 INITRAMFS_IMAGE_BUNDLE ?= ""
 
+IMAGE_FEATURES += '${@bb.utils.contains("OVERC_ESSENTIAL_MODE", "read-only", "read-only-rootfs", "",d)}'
+
 inherit core-image
 inherit builder-base
+
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs", "read_only_essential; ", "read_write_essential; ",d)}'
+
+read_only_essential () {
+    echo "none	/etc/openvswitch	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    mkdir -p ${IMAGE_ROOTFS}/opt/container
+    echo "none	/opt/container	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    echo "none	/var/lib/misc	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
+    if [ -e ${IMAGE_ROOTFS}/etc/hosts ]; then
+        mv ${IMAGE_ROOTFS}/etc/hosts ${IMAGE_ROOTFS}/etc/hosts0
+        ln -s ../run/systemd/resolve/hosts ${IMAGE_ROOTFS}/etc/hosts
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/dnsmasq.conf ]; then
+        mv ${IMAGE_ROOTFS}/etc/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf0
+        ln -s ../run/systemd/resolve/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf
+    fi
+    ln -s ../run/systemd/resolve/resolv.conf ${IMAGE_ROOTFS}/etc/resolv.conf
+    if [ -e ${IMAGE_ROOTFS}/etc/system-id ]; then
+        rm ${IMAGE_ROOTFS}/etc/system-id -f
+    fi
+    ln -s ../run/systemd/resolve/system-id ${IMAGE_ROOTFS}/etc/system-id
+    if [ -e ${IMAGE_ROOTFS}/lib/systemd/system/cube-cmd-server.service ]; then
+	sed -i '/^\[Service\]/a\\ExecStartPre=/bin/sh -c "mkdir -p  /opt/container/dom0 /opt/container/cube-desktop /opt/container/all /opt/container/local"' ${IMAGE_ROOTFS}/lib/systemd/system/cube-cmd-server.service
+    fi
+    if [ -e ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service ]; then
+	sed -i '/ExecStart/d' ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service
+	sed -i '/^\[Service\]/a\\ \
+ExecStartPre=/bin/sh -c "cp /etc/hosts0 /run/systemd/resolve/hosts" \
+ExecStartPre=/bin/sh -c "cp /etc/dnsmasq.conf0 /run/systemd/resolve/dnsmasq.conf" \
+ExecStart=/bin/sh -c "/usr/bin/ansible-playbook /etc/overc-conf/ansible/overc.yml" \
+' ${IMAGE_ROOTFS}/lib/systemd/system/overc-conftools.service
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/systemd/network/20-wired.network ]; then
+	rm -f ${IMAGE_ROOTFS}/etc/systemd/network/20-wired.network
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/overc-conf/network_prime/25-br-int.network.essential ]; then
+	cp ${IMAGE_ROOTFS}/etc/overc-conf/network_prime/25-br-int.network.essential ${IMAGE_ROOTFS}/etc/systemd/network/25-br-int.network
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/overc-conf/ansible/essential.yml ]; then
+        sed -i '/Copy networkd systemd configuration.*essential/,/25-br-int.network.essential/d' ${IMAGE_ROOTFS}/etc/overc-conf/ansible/essential.yml
+        sed -i '/Remove default configuration.*essential/,/20-wired.network/d' ${IMAGE_ROOTFS}/etc/overc-conf/ansible/essential.yml
+        sed -i '/^ *file.*20-wired.network.essential/,/}/d' ${IMAGE_ROOTFS}/etc/overc-conf/ansible/essential.yml
+        sed -i 's/\/etc\/resolv.conf/\/run\/systemd\/resolve\/resolv.conf/g' ${IMAGE_ROOTFS}/etc/overc-conf/ansible/essential.yml
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/overc-conf/ansible/post.yml ]; then
+        sed -i '/name: disable configure_network_prime/,/replace:.*configure_network_prime/d' ${IMAGE_ROOTFS}/etc/overc-conf/ansible/post.yml
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/overc-conf/network_prime/autonetdev ]; then
+        sed -i '/echo lxc.network.type = /i\    sed -i "/lxc.network.type = phys/d" $config\' ${IMAGE_ROOTFS}/etc/overc-conf/network_prime/autonetdev
+        sed -i '/echo lxc.network.type = /i\    sed -i "/lxc.network.link/d" $config\' ${IMAGE_ROOTFS}/etc/overc-conf/network_prime/autonetdev
+    fi
+    if [ -e ${IMAGE_ROOTFS}/etc/ansible/ansible.cfg ]; then
+	sed -i '/^\[defaults\]/a\\ \
+remote_tmp     = /var/lib/misc \
+local_tmp      = /var/lib/misc \
+' ${IMAGE_ROOTFS}/etc/ansible/ansible.cfg
+    fi
+    ln -s ../run/systemd/resolve/localtime ${IMAGE_ROOTFS}/etc/localtime
+    ln -s ../run/systemd/resolve/timezone ${IMAGE_ROOTFS}/etc/timezone
+    ln -s /run/systemd/resolve/cube-cmd-server.log ${IMAGE_ROOTFS}/var/log/cube-cmd-server.log
+}
+
+read_write_essential () {
+   if [ -e ${IMAGE_ROOTFS}/${sysconfdir}/profile.d/essential_rw.sh ]; then
+       rm -f ${IMAGE_ROOTFS}/${sysconfdir}/profile.d/essential_rw.sh
+   fi
+}

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayclean
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayclean
@@ -1,5 +1,0 @@
-#!/bin/sh -
-
-# Remove all served request from lxc-overlayrestore
-
-sed -i "\@/etc/lxc/overlay@d" /etc/lxc/lxc-overlayrestore

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayrestore
@@ -2,3 +2,9 @@
 
 # Rebuild an overlay-ed directory
 # Or turn an overlay-ed directroy into orignal state
+
+if [ -e /var/lib/lxc/overlayrestore ]; then
+	chmod +x /var/lib/lxc/overlayrestore
+	/var/lib/lxc/overlayrestore
+	rm /var/lib/lxc/overlayrestore
+fi

--- a/meta-cube/recipes-core/lxc/files/lxc-overlayscan
+++ b/meta-cube/recipes-core/lxc/files/lxc-overlayscan
@@ -38,6 +38,11 @@ if [ $(ls -Al "$2"|wc -l) -eq 1 ]; then
 fi
 }
 
+#0.Check flag file
+if [ ! -e /var/lib/lxc/need_scan_duplicate ]; then
+	exit 0
+fi
+
 # 1.List all containers
 for cn in $(lxc-ls); do
 # 2.Open /var/lib/lxc/$container/fstab, list all overlay mount entry
@@ -63,4 +68,4 @@ for cn in $(lxc-ls); do
 done;
 
 # Remove service from lxc.service
-sed -i "/lxc-overlayscan/d" /lib/systemd/system/lxc.service
+rm -f /var/lib/lxc/need_scan_duplicate

--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -13,7 +13,6 @@ SRC_URI += " \
     file://ovs-down \
     file://lxc-overlayscan \
     file://lxc-overlayrestore \
-    file://lxc-overlayclean \
     file://overlayrestore \
     file://overlaycreate \
     file://silence_no_escape_lxc-console.patch \
@@ -28,7 +27,7 @@ do_install_append(){
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
 	sed -i 's/\(After=.*$\)/\1 openvswitch-nonetwork.service/' ${D}${systemd_unitdir}/system/lxc.service
 	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
-ExecStartPre=/etc/lxc/lxc-overlayrestore\nExecStartPre=/etc/lxc/lxc-overlayclean
+ExecStartPre=/etc/lxc/lxc-overlayscan\nExecStartPre=/etc/lxc/lxc-overlayrestore
 }' ${D}${systemd_unitdir}/system/lxc.service
 
 	# disable the dmesg output on the console when booting the containers,
@@ -47,7 +46,6 @@ ExecStartPre=/etc/lxc/lxc-overlayrestore\nExecStartPre=/etc/lxc/lxc-overlayclean
 	# add script to scan dir mount with overlay to delete duplicate file
 	install -m 755 ${WORKDIR}/lxc-overlayscan ${D}/etc/lxc/lxc-overlayscan
 	install -m 755 ${WORKDIR}/lxc-overlayrestore ${D}/etc/lxc/lxc-overlayrestore
-	install -m 755 ${WORKDIR}/lxc-overlayclean ${D}/etc/lxc/lxc-overlayclean
 	install -m 755 ${WORKDIR}/overlayrestore ${D}/etc/lxc/overlayrestore
 	install -m 755 ${WORKDIR}/overlaycreate ${D}/etc/lxc/overlaycreate
 }

--- a/meta-cube/recipes-support/overc-conftools/overc-conftools_1.1.bb
+++ b/meta-cube/recipes-support/overc-conftools/overc-conftools_1.1.bb
@@ -35,6 +35,7 @@ SRC_URI = " \
     file://source/ansible/overc.yml \
     file://source/ansible/post.yml \
     file://source/ansible/setup_offset.yml \
+    file://source/essential_rw.sh \
 "
 
 S = "${WORKDIR}"
@@ -69,6 +70,9 @@ do_install() {
     # systemd services
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/source/overc-conftools.service ${D}${systemd_unitdir}/system/
+
+    install -d ${D}/${sysconfdir}/profile.d/
+    install -m 0644 ${WORKDIR}/source/essential_rw.sh ${D}/${sysconfdir}/profile.d/
 }
 
 RDEPENDS_${PN} += " \

--- a/meta-cube/recipes-support/overc-conftools/source/essential_rw.sh
+++ b/meta-cube/recipes-support/overc-conftools/source/essential_rw.sh
@@ -1,0 +1,26 @@
+rw_test=`mount |grep " / "|grep rw`
+
+if [ -z "$rw_test" ]; then
+	if read -t 5 -p "Essential is read-only, if you need to login as read-write, please enter \"yes\":" rw_allow
+	then
+		if [ "$rw_allow" == "yes" ]; then
+			mount / -o remount,rw
+		fi
+	fi
+else
+	if read -t 5 -p "Essential is read-write, if you need to login as read-only, please enter \"yes\":" rw_allow
+	then
+		if [ "$rw_allow" == "yes" ]; then
+			umount /
+		fi
+	fi
+fi
+echo
+rw_test=`mount |grep " / "|grep rw`
+
+if [ ! -z "$rw_test" ]; then
+	echo "Warning, Essential rootfs is in read-write, all modification on essential will be recorded."
+	echo "To return read-only, please issue \"umount /\" or reboot system."
+else
+	echo "Essential is in read-only."
+fi

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -224,7 +224,7 @@ class Container(object):
 		    print "%s:already an overlay-ed dir in container" % (oldir)
 	            return -1
         # Insert request into lxc.service
-        lxcfile = '%s/etc/lxc/lxc-overlayrestore' % (ROOTMOUNT)
+        lxcfile = '%s/overlayrestore' % (CONTAINER_MOUNT)
         lxc = open(lxcfile, 'a+')
         lines=lxc.readlines()
         found = 0

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -79,21 +79,9 @@ class Overc(object):
         rc = self._host_upgrade(0, force)
 
         if ((overlay_flag == 1) and (skipscan == 0) and (rc == 1)):
-            # Enable lxc-overlay service in essential
-            lxcfile = '%s/%s/lib/systemd/system/lxc.service' % (SYSROOT, self.agency.next_rootfs)
-            lxc = open(lxcfile, 'r')
-            lines = lxc.readlines()
-            lxc.close()
-            for line in lines:
-                if line.find("lxc_overlay") != -1:
-                    sys.exit(self.retval)
-            for line in lines:
-                if line.find("ExecStart") != -1:
-                    index = lines.index(line)
-                    break
-            lines.insert(index, "ExecStartPre=/etc/lxc/lxc-overlayscan\n")
-            lxc = open(lxcfile, 'w')
-            lxc.writelines(lines)
+            # Enable lxc-overlay service in essential by create a flagfile in CONTAINER_MOUNT
+            lxcfile = '%s/need_scan_duplicate' % (CONTAINER_MOUNT)
+            lxc = open(lxcfile, 'w+')
             lxc.close()
 
         if ((rc == 1) and (reboot != 0)):


### PR DESCRIPTION
[v3]:
1.Add OVERC_ESSENTIAL_MODE in meta-overc layer to control rw attribute of essential rootfs. By default, it is read-only, user may change it by update it in local.conf

2.Add notes about limitation of ro rootfs & instruction to change rw attribute of essential rootfs in README.install.

3.Removed puppet stuff in commit log.

[v2]:
1.Make readonly fs working with ansible.
2.Fix typo in script
3.Update commit log for patch.

[v1 log]:
This pull-request contain 3 patch:
1.patch 1 create a read-only essential by adding read-only-rootfs in IMAGE_FEATURES. Also created new mount entry & temporary file to make overc required service working on readonly rootfs, including openvswitch, puppet, cube-cmd-serive.

2.patch 2 add a script in /etc/profile.d to generate Warning message & allow user change read/write attribute when login to essential.

3.patch 3 update lxc to allow overlayfs related service working on readonly essential.

Testing including:
1.booting: some systemd service still failed, but it won't affect overc running.
2.cube-cmd,cube-console
3.network