### PR TITLE
linux-yocto:Disable builder.cfg by default

### DIFF
--- a/README.install
+++ b/README.install
@@ -22,6 +22,9 @@ container runtimes. These are:
  - cube-builder: This is the image which lists all the packages required to
                  boot the platform. cube-builder is also capable of self
                  hosting and building the platform itself.
+                 Please add following line in local.conf before building
+                 kernel for cube-builder:
+                  OVERC_PLATFORM_TUNING += "builder"
  - cube-essential: This is a minimal runtime which is used for both the
                    installer and cube-essential in the fully assembled system.
 

--- a/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}:${THISDIR}/linux-yocto:"
 
-SRC_URI += "file://builder.cfg"
+SRC_URI += '${@bb.utils.contains("OVERC_PLATFORM_TUNING", "builder", "file://builder.cfg ", "",d)}'
 SRC_URI += "file://xt-checksum.scc \
             file://ebtables.scc \
             file://vswitch.scc \

--- a/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}:${THISDIR}/linux-yocto:"
 
-SRC_URI += "file://builder.cfg"
+SRC_URI += '${@bb.utils.contains("OVERC_PLATFORM_TUNING", "builder", "file://builder.cfg ", "",d)}'
 SRC_URI += "file://xt-checksum.scc \
             file://ebtables.scc \
             file://vswitch.scc \


### PR DESCRIPTION
Since builder.cfg will disable preempt in kernel. We disable this kernel
fragment by default.
If user want to enable builder.cfg for cube-builder project, need add
following line in local.conf:
  OVERC_PLATFORM_TUNING += "builder"

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>