### PR TITLE
openvswitch: mirror changes in ovs uprev

### DIFF
--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -26,7 +26,7 @@ do_install_append(){
 	# remove the dependancy from lxc.service to reduce the boottime.
 
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
-	sed -i 's/\(After=.*$\)/\1 openvswitch-nonetwork.service/' ${D}${systemd_unitdir}/system/lxc.service
+	sed -i 's/\(After=.*$\)/\1 openvswitch.service/' ${D}${systemd_unitdir}/system/lxc.service
 	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
 ExecStartPre=/etc/lxc/lxc-overlayscan\nExecStartPre=/etc/lxc/lxc-overlayrestore
 }' ${D}${systemd_unitdir}/system/lxc.service

--- a/meta-cube/recipes-support/overc-conftools/source/overc-conftools.service
+++ b/meta-cube/recipes-support/overc-conftools/source/overc-conftools.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OverC system configuration service
-After=local-fs.target openvswitch-nonetwork.service network.target
+After=local-fs.target openvswitch.service network.target
 Before=lxc.service
 
 [Service]


### PR DESCRIPTION
The openvswitch uprev (v2.6.1) just completed in meta-virtualization
resulted in a reorganisation of the systemd service names for
ovs. Reflect these changes here to ensure services have valid
dependencies.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>