### PR TITLE
bolt: fix build failure due to GOROOT

### DIFF
--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -28,7 +28,7 @@ do_install_append(){
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
 	sed -i 's/\(After=.*$\)/\1 openvswitch.service/' ${D}${systemd_unitdir}/system/lxc.service
 	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
-ExecStartPre=/etc/lxc/lxc-overlayscan\nExecStartPre=/etc/lxc/lxc-overlayrestore
+ExecStartPre=sh -c "/etc/lxc/lxc-overlayscan"\nExecStartPre=sh -c "/etc/lxc/lxc-overlayrestore"
 }' ${D}${systemd_unitdir}/system/lxc.service
 
 	# disable the dmesg output on the console when booting the containers,


### PR DESCRIPTION
Similar to most of build failures caused by GOROOT, this fix resolves
the following errors when sstate becomes invalid:

| DEBUG: Executing shell function do_compile
| go: cannot find GOROOT directory:
wr-core/build-helios/tmp/sysroots/x86_64-linux/usr/lib/x86_64-wrs-linux/go

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>