### PR TITLE
go: reflect go-cross renamed to go-cross-${TARGET_ARCH}

### DIFF
--- a/meta-cube/classes/golang.bbclass
+++ b/meta-cube/classes/golang.bbclass
@@ -1,4 +1,4 @@
-DEPENDS += "go-cross"
+DEPENDS += "go-cross-${TARGET_ARCH}"
 
 S = "${WORKDIR}/git"
 

--- a/meta-cube/recipes-connectivity/serf/serf-go_git.bb
+++ b/meta-cube/recipes-connectivity/serf/serf-go_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/hashicorp/serf"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b278a92d2c1509760384428817710378"
 
-DEPENDS += "go-cross \
+DEPENDS += "go-cross-${TARGET_ARCH} \
     cli \
     logutils \
     columnize \

--- a/meta-cube/recipes-devtools/go/mdns_git.bb
+++ b/meta-cube/recipes-devtools/go/mdns_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/hashicorp/mdns"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=cb04212e101fbbd028f325e04ad45778"
 
-DEPENDS += "go-cross dns"
+DEPENDS += "go-cross-${TARGET_ARCH} dns"
 
 PKG_NAME = "github.com/hashicorp/mdns"
 SRC_URI = "git://${PKG_NAME}.git"


### PR DESCRIPTION
In meta-virtualization we have renamed go-cross to
go-cross-${TARGET_ARCH} to allow per recipes sysroot to function
correctly and to reflect the fact that this crosstool has arch
specific bindings. We need to carry that rename through to the recipes
in this layer to prevent looking for and not finding go-cross.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>