### PR TITLE
cube-builder-initramfs: allow to install the packages defined in IMAG…

### DIFF
--- a/meta-cube/recipes-core/images/cube-builder-initramfs.bb
+++ b/meta-cube/recipes-core/images/cube-builder-initramfs.bb
@@ -7,7 +7,7 @@ CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL ?= ""
 
 # Archived variant for running a full installer from the initramfs
 # PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 vim which sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
-PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL} ${IMAGE_INSTALL}"
 PACKAGE_EXCLUDE = "busybox busybox-dev busybox-udhcpc busybox-dbg busybox-ptest busybox-udhcpd busybox-hwclock busybox-syslog"
 
 IMAGE_INSTALL += " \


### PR DESCRIPTION
…E_INSTALL

PACKAGE_INSTALL is originally designed to include IMAGE_INSTALL for
collecting the installed packages. cube-builder-initramfs redefines
PACKAGE_INSTALL and doesn't include IMAGE_INSTALL. It is necessary
to install the packages set by IMAGE_INSTALL.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>