### PR TITLE
cube-builder-initramfs: install the packages defined in _EXTRA_INSTALL

### DIFF
--- a/meta-cube/recipes-core/images/cube-builder-initramfs.bb
+++ b/meta-cube/recipes-core/images/cube-builder-initramfs.bb
@@ -7,12 +7,8 @@ CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL ?= ""
 
 # Archived variant for running a full installer from the initramfs
 # PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 vim which sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
-PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
+PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL} ${CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL}"
 PACKAGE_EXCLUDE = "busybox busybox-dev busybox-udhcpc busybox-dbg busybox-ptest busybox-udhcpd busybox-hwclock busybox-syslog"
-
-IMAGE_INSTALL += " \
-                  ${CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL} \
-                 "
 
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""

--- a/meta-cube/recipes-core/initrdscripts/files/init-server.sh
+++ b/meta-cube/recipes-core/initrdscripts/files/init-server.sh
@@ -87,7 +87,7 @@ mkdir -p $ROOT_MOUNT/
 sleep ${ROOT_DELAY}
 
 try_to_mount_rootfs() {
-    local mount_flags="rw,noatime"
+    local mount_flags="rw,noatime,iversion"
 
     mount -o $mount_flags "${ROOT_DEVICE}" "${ROOT_MOUNT}" 2>/dev/null && return 0
 


### PR DESCRIPTION
PACKAGE_INSTALL is originally designed to include IMAGE_INSTALL for
collecting the installed packages. cube-builder-initramfs redefines
PACKAGE_INSTALL and doesn't include IMAGE_INSTALL.

In order to append the external packages, add
CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL to PACKAGE_INSTALL.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>