### PR TITLE
linux-yocto*: install the bundled kernel only

### DIFF
--- a/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -37,3 +37,22 @@ KERNEL_FEATURES_append = " cfg/fs/ext2.scc"
 
 # we are ok with version mismatches, since AUTOREV is frequently used
 deltask kernel_version_sanity_check
+
+# Don't install the normal kernel image if the bundled kernel configured
+python __anonymous () {
+    if d.getVar('INITRAMFS_IMAGE', True) and \
+       d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1':
+
+        tfmake = d.getVar('KERNEL_IMAGETYPE_FOR_MAKE', True) or ""
+
+        for type in tfmake.split():
+            typelower = type.lower()
+
+            rkis = d.getVar('RDEPENDS_kernel-image', True) or ""
+            rkistr = ' '
+            for rki in rkis.split():
+                if rki != 'kernel-image-' + typelower:
+                    rkistr += ' ' + rki
+
+            d.setVar('RDEPENDS_kernel-image', rkistr)
+}

--- a/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
@@ -16,3 +16,22 @@ KERNEL_FEATURES_append = " cfg/fs/ext2.scc"
 
 # we are ok with version mismatches, since AUTOREV is frequently used
 deltask kernel_version_sanity_check
+
+# Don't install the normal kernel image if the bundled kernel configured
+python __anonymous () {
+    if d.getVar('INITRAMFS_IMAGE', True) and \
+       d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1':
+
+        tfmake = d.getVar('KERNEL_IMAGETYPE_FOR_MAKE', True) or ""
+
+        for type in tfmake.split():
+            typelower = type.lower()
+
+            rkis = d.getVar('RDEPENDS_kernel-image', True) or ""
+            rkistr = ' '
+            for rki in rkis.split():
+                if rki != 'kernel-image-' + typelower:
+                    rkistr += ' ' + rki
+
+            d.setVar('RDEPENDS_kernel-image', rkistr)
+}

--- a/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -17,3 +17,22 @@ KERNEL_FEATURES_append = " cfg/fs/ext2.scc"
 
 # we are ok with version mismatches, since AUTOREV is frequently used
 deltask kernel_version_sanity_check
+
+# Don't install the normal kernel image if the bundled kernel configured
+python __anonymous () {
+    if d.getVar('INITRAMFS_IMAGE', True) and \
+       d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1':
+
+        tfmake = d.getVar('KERNEL_IMAGETYPE_FOR_MAKE', True) or ""
+
+        for type in tfmake.split():
+            typelower = type.lower()
+
+            rkis = d.getVar('RDEPENDS_kernel-image', True) or ""
+            rkistr = ' '
+            for rki in rkis.split():
+                if rki != 'kernel-image-' + typelower:
+                    rkistr += ' ' + rki
+
+            d.setVar('RDEPENDS_kernel-image', rkistr)
+}


### PR DESCRIPTION
If the bundled kernel is configured, the normal kernel image won't be
installed any more.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>