### PR TITLE
overc-system-agent:add support for fitImage

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -22,6 +22,8 @@ class Btrfs(Utils):
             self.kernel = "/boot/uImage"
         elif os.path.exists('/boot/zImage'):
             self.kernel = "/boot/zImage"
+        elif os.path.exists('/boot/fitImage'):
+            self.kernel = "/boot/fitImage"
         elif os.path.exists('/boot/kernel7.img'):
             self.kernel = "/boot/kernel7.img"
 


### PR DESCRIPTION
uboot supports fitImage as boot image type, add it into overc-system-agent.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>