### PR TITLE
ifupdown: fix the issue of missing inherit update-alternatives

### DIFF
--- a/meta-cube/recipes-core/ifupdown/ifupdown_0.7.48.1.bb
+++ b/meta-cube/recipes-core/ifupdown/ifupdown_0.7.48.1.bb
@@ -18,7 +18,7 @@ EXTRA_OEMAKE = ""
 S = "${WORKDIR}/ifupdown-${PV}ubuntu5"
 
 
-inherit update-rc.d systemd
+inherit update-rc.d systemd update-alternatives
 
 do_compile () {
 	chmod a+rx *.pl *.sh


### PR DESCRIPTION
In order to make ALTERNATIVE function work,
it should inherit update-alternatives class.

Signed-off-by: fli <fupan.li@windriver.com>