### PR TITLE
layer.conf: make 'read-only' overrideable

### DIFF
--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -60,4 +60,4 @@ SYSVINIT_SCRIPTS_remove_pn-packagegroup-core-boot = "busybox-hwclock"
 # OVERC_ESSENTIAL_MODE describes the read/write mode of essential rootfs in OverC. By
 # default, essential rootfs is read-only. To change it to read-write, please update
 # value to "read-write", then rebuild essential rootfs.
-OVERC_ESSENTIAL_MODE = "read-only"
+OVERC_ESSENTIAL_MODE ?= "read-only"


### PR DESCRIPTION
Commit bcc76fbc587c [Essential:make essential as read-only by default]
used '=' instead of '?=' making this non-overwriteable. Use the
correct operator in order to allow folks to overwrite this in their
local.conf or elsewhere.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>