### PR TITLE
overc-utils: RDEPEND on systemd-extra-utils

### DIFF
--- a/meta-cube/recipes-support/overc-utils/overc-utils_git.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_git.bb
@@ -52,4 +52,4 @@ FILES_${PN} += "/opt/${BPN} \
 
 FILES_overc-device-utils += "${sbindir}/cube-device ${sysconfdir}/udev ${sysconfdir}/cube-device"
 
-RDEPENDS_${PN} += "bash dtach nanoio nanoio-client udev"
+RDEPENDS_${PN} += "bash dtach nanoio nanoio-client udev systemd-extra-utils"


### PR DESCRIPTION
oe-core commit bc017488bb53 [systemd: move some tools into
systemd-extra-utils package] resulted in our images which have
cube-ctl and cube-console missing the required
systemd-detect-virt. Add a direct RDEPENDS to avoid this.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>