### PR TITLE
meta-overc: run the shell script in bash command

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime-port-forward.service
+++ b/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime-port-forward.service
@@ -4,7 +4,7 @@ After=systemd-networkd.service
 
 [Service]
 Type=oneshot
-ExecStart=/etc/overc/network_prime_port_forward.sh
+ExecStart=/bin/bash /etc/overc/network_prime_port_forward.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When IMA feature is enabled, all of the programs should be
signed, otherwise it will be denied when run it. OverC's IMA
signing steps are executed at the installing stage, and the script
network_prime_port_forward.sh is deployed into network prime container
at the system first boot stage, thus there is no chance to sign this script
and it will be denied to run it without signing. Executing the script in a
signed bash instead of run it directly will fix this issue.

Signed-off-by: fli <fupan.li@windriver.com>