### PR TITLE
screen-getty: Turn off use of alternate screen

### DIFF
--- a/meta-cube/recipes-extended/screen-getty/files/screen-gettyrc
+++ b/meta-cube/recipes-extended/screen-getty/files/screen-gettyrc
@@ -44,3 +44,6 @@ bind 7 select 7
 bind 8 select 8
 bind 9 select 9
 
+# Turn off alternate screen and allow scrollback for putty/gnome-terminal
+termcapinfo xterm ti@:te@
+


### PR DESCRIPTION
Disabling the alternate screen allows for standard scrollback
functions to work on gnome-terminal and putty.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>