### PR TITLE
plfask:  Fix parallel make problem

### DIFF
--- a/meta-cube/recipes-containers/pflask/pflask/Makefile
+++ b/meta-cube/recipes-containers/pflask/pflask/Makefile
@@ -134,7 +134,7 @@ build: $(build_targets)
 
 clean: $(clean_targets)
 
-install: build $(install_targets)
+install: $(install_targets)
 
 uninstall: $(uninstall_targets)
 


### PR DESCRIPTION
Two copies of gcc can get running on the same c file to the same
location and you get an error like:

tmp/work/core2-64-wrs-linux/pflask/git-r0/git/build/src/sync.1.o: file not recognized: File truncated

The install rule depends and builds all the objects so the build rule
is effectively not used.  With the build rule there it will run in
parallel to the install objects rules which build the same files.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>