### PR TITLE
Housekeeping: Set S if recipe has a SRC_URI but doesn't use default S

### DIFF
--- a/meta-cube/recipes-core/initrdscripts/initramfs-cube-builder.bb
+++ b/meta-cube/recipes-core/initrdscripts/initramfs-cube-builder.bb
@@ -3,6 +3,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 SRC_URI = "file://init-server.sh"
 
+S = "${WORKDIR}"
+
 PR = "r9"
 
 RDEPENDS_${PN} = "parted e2fsprogs-mke2fs"

--- a/meta-cube/recipes-support/container-shutdown-notifier/container-shutdown-notifier.bb
+++ b/meta-cube/recipes-support/container-shutdown-notifier/container-shutdown-notifier.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 
 RDEPENDS_${PN} = "bash overc-utils cube-cmd-server-functions"
 
+S = "${WORKDIR}"
+
 SRC_URI = "file://container-shutdown-notifier \
            file://container-shutdown-notifier.service \
 "

--- a/meta-cube/recipes-support/cube-cmd-server/cube-cmd-server.bb
+++ b/meta-cube/recipes-support/cube-cmd-server/cube-cmd-server.bb
@@ -10,6 +10,9 @@ SRC_URI = "file://cube-cmd-server \
            file://cube-cmd-server.conf \
            file://cube-cmd-server-functions \
 "
+
+S = "${WORKDIR}"
+
 RDEPENDS_${PN} = "bash gawk dtach cube-cmd-server-functions nanoio nanoio-server"
 
 inherit systemd

--- a/meta-cube/recipes-support/dom0-contctl/dom0-contctl_1.0.bb
+++ b/meta-cube/recipes-support/dom0-contctl/dom0-contctl_1.0.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 
 RDEPENDS_${PN} = "util-linux lxc bash python cgmanager"
 
+S = "${WORKDIR}"
+
 SRC_URI = "file://dom0_contctl \
            file://lxc_driver.sh \
            file://dom0-containers \


### PR DESCRIPTION
Recipes which have a SRC_URI but don't unpack/fetch to the default S
directory should set 'S = "{WORKDIR}"'. Using the default S in these
cases used to cause a QA Warning but a bug which is currently always
creating the default ${WORKDIR}/${BPN}-${PV} directory results in the
QA Warning being 'hidden'.

For folks using meta-overc with older Yocto releases this will cut
down on the build noise. Since the bug which was 'hiding' the QA
warning has been raised with the associated devs by fixing this now we
avoid seeing the QA warnings when/if the bug is fixed.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>