### PR TITLE
lvm2: do not run 10-dm.rules in a container

### DIFF
--- a/meta-cube/recipes-support/lvm2/files/container-skip-to-dm_end.patch
+++ b/meta-cube/recipes-support/lvm2/files/container-skip-to-dm_end.patch
@@ -1,0 +1,21 @@
+In the case of using a container the dm rules should be skipped.
+
+These will be running in the root name space and re-processing from a
+privileged with a read/write /sys will end badly with duplication of
+processing of dmsetup and volumes getting unmounted.
+
+---
+ udev/10-dm.rules.in |    2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/udev/10-dm.rules.in
++++ b/udev/10-dm.rules.in
+@@ -18,6 +18,8 @@ KERNEL=="device-mapper", NAME="(DM_DIR)/
+ 
+ SUBSYSTEM!="block", GOTO="dm_end"
+ KERNEL!="dm-[0-9]*", GOTO="dm_end"
++IMPORT{file}="/proc/1/environ"
++ENV{container}=="?*", GOTO="dm_end"
+ (DM_EXEC_RULE)
+ 
+ # Device created, major and minor number assigned - "add" event generated.

--- a/meta-cube/recipes-support/lvm2/lvm2_%.bbappend
+++ b/meta-cube/recipes-support/lvm2/lvm2_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://container-skip-to-dm_end.patch"
+


### PR DESCRIPTION
Only the root name space can run the 10-dm.rules for udev.  If more
than one entity such as a privileged container invokes the dmsetup
routines to manipulate volumes automatically the root name space will
start unmounting volumes at runtime for the whole system.

This was found when using a special encrypted volume for the system
journal as a shared resource between the containers and the root name
space so as to make the logs all visible in the privileged container.

This type of manipulation is generally only done when the system is
started and it allows the containers to freely start and stop as well
as have the possibility of a r/w /sys.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>