### PR TITLE
Have ansible use python3

### DIFF
--- a/meta-cube/recipes-devtools/python/python-ansible.inc
+++ b/meta-cube/recipes-devtools/python/python-ansible.inc
@@ -1,0 +1,31 @@
+DESCRIPTION = "Ansible is a simple IT automation platform that makes your applications and systems easier to deploy."
+HOMEPAGE = "https://github.com/ansible/ansible/"
+SECTION = "devel/python"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=8f0e2cd40e05189ec81232da84bd6e1a"
+
+SRCNAME = "ansible"
+
+SRC_URI = "http://releases.ansible.com/ansible/${SRCNAME}-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "b1be8f05864a07c06b8a767dcd48ba1b"
+SRC_URI[sha256sum] = "cd4b8f53720fcd0c351156b840fdd15ecfbec22c951b5406ec503de49d40b9f5"
+
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+do_install_append() {
+    # install hosts and conf
+    install -d ${D}/${sysconfdir}/ansible
+
+    # There is no default inventory configuration installed for ansible,
+    # so we use the example as a template to improve OOBE.
+    install ${S}/examples/hosts ${D}/${sysconfdir}/ansible/
+    install ${S}/examples/ansible.cfg ${D}/${sysconfdir}/ansible/
+
+    # do not gather machine's information, which could reduce setup time
+    sed -i "s|^#gathering = implicit|gathering = explicit|g" \
+        ${D}/${sysconfdir}/ansible/ansible.cfg
+}
+
+CLEANBROKEN = "1"

--- a/meta-cube/recipes-devtools/python/python-ansible_2.3.1.0.bb
+++ b/meta-cube/recipes-devtools/python/python-ansible_2.3.1.0.bb
@@ -1,33 +1,4 @@
-DESCRIPTION = "Ansible is a simple IT automation platform that makes your applications and systems easier to deploy."
-HOMEPAGE = "https://github.com/ansible/ansible/"
-SECTION = "devel/python"
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://COPYING;md5=8f0e2cd40e05189ec81232da84bd6e1a"
-
-SRCNAME = "ansible"
-
-SRC_URI = "http://releases.ansible.com/ansible/${SRCNAME}-${PV}.tar.gz"
-
-SRC_URI[md5sum] = "b1be8f05864a07c06b8a767dcd48ba1b"
-SRC_URI[sha256sum] = "cd4b8f53720fcd0c351156b840fdd15ecfbec22c951b5406ec503de49d40b9f5"
-
-
-S = "${WORKDIR}/${SRCNAME}-${PV}"
-
 inherit setuptools
-
-do_install_append() {
-    # install hosts and conf
-    install -d ${D}/${sysconfdir}/ansible
-
-    # There is no default inventory configuration installed for ansible,
-    # so we use the example as a template to improve OOBE.
-    install ${S}/examples/hosts ${D}/${sysconfdir}/ansible/
-    install ${S}/examples/ansible.cfg ${D}/${sysconfdir}/ansible/
-
-    # do not gather machine's information, which could reduce setup time
-    sed -i "s|^#gathering = implicit|gathering = explicit|g" \
-        ${D}/${sysconfdir}/ansible/ansible.cfg
-}
+require python-ansible.inc
 
 RDEPENDS_${PN} += "python-pyyaml python-jinja2 python-modules"

--- a/meta-cube/recipes-devtools/python/python-ansible_2.3.1.0.bb
+++ b/meta-cube/recipes-devtools/python/python-ansible_2.3.1.0.bb
@@ -8,8 +8,8 @@ SRCNAME = "ansible"
 
 SRC_URI = "http://releases.ansible.com/ansible/${SRCNAME}-${PV}.tar.gz"
 
-SRC_URI[md5sum] = "d2521bc6416d07996e924fdd2d1fa6a2"
-SRC_URI[sha256sum] = "61e739c123923ba90169f42c54e5f51df759ed40b4e332a7160d7db963d5678b"
+SRC_URI[md5sum] = "b1be8f05864a07c06b8a767dcd48ba1b"
+SRC_URI[sha256sum] = "cd4b8f53720fcd0c351156b840fdd15ecfbec22c951b5406ec503de49d40b9f5"
 
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"

--- a/meta-cube/recipes-devtools/python/python3-ansible_2.3.1.0.bb
+++ b/meta-cube/recipes-devtools/python/python3-ansible_2.3.1.0.bb
@@ -1,0 +1,4 @@
+inherit setuptools3
+require python-ansible.inc
+
+RDEPENDS_${PN} += "python3-pyyaml python3-jinja2 python3-modules"

--- a/meta-cube/recipes-support/overc-conftools/overc-conftools_1.1.bb
+++ b/meta-cube/recipes-support/overc-conftools/overc-conftools_1.1.bb
@@ -83,7 +83,7 @@ do_install() {
 }
 
 RDEPENDS_${PN} += " \
-    python-ansible \
+    python3-ansible \
     bash \
     "
 

--- a/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
+++ b/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
@@ -13,13 +13,13 @@ SYSTEMD_SERVICE_${PN} = "factory-reset.service"
 
 RDEPENDS_${PN} = "\
 	btrfs-tools \
-	python-argparse \
-	python-subprocess \
-	python-flask \
-	python-itsdangerous \
-	python-jinja2 \
-	python-markupsafe \
-	python-werkzeug \
+	python3-argparse \
+	python3-subprocess \
+	python3-flask \
+	python3-itsdangerous \
+	python3-jinja2 \
+	python3-markupsafe \
+	python3-werkzeug \
 	bash \
 	bc \
 	overc-installer \


### PR DESCRIPTION
Uprev ansible to a newer version which is needed to move to py3. Split the recipe to allow py2 and py3 versions of ansible. This was tested with sample playbooks that included operations such as ping and similar. In master-oci most of the work we used to do in ansible is no more but I did ensure the service is run on boot and presents no issues.