### PR TITLE
local.conf.sample: remove dev-pkgs from IMAGE_FEATURES

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -152,7 +152,6 @@ NOISO = "1"
 IMAGE_FSTYPES += "ext3"
 IMAGE_FSTYPES_remove = "wic wic.bmap"
 
-IMAGE_FEATURES += "dev-pkgs"
 #IMAGE_FEATURES += "splash ssh-server-openssh hwcodecs package-management"
 IMAGE_FEATURES += "ssh-server-openssh package-management"
 # do not install recommendations


### PR DESCRIPTION
As far as I can tell (no real git history on the choice to set this
image feature) this is a holdover from the original work to create a
self-builder and serves no real usecases we have for meta-overc. The
only thing this accomplishes is to make our images larger than they
need to be, counter to what we are attempting to accomplish,
especially with cube-essential. I thought about commenting this out
but there is already a full description in the text just below where
this was and this is also usually added via EXTRA_IMAGE_FEATURES.

As a side note the inclusion of dev-pkgs had a somewhat unexpected
double whammy effect on the image size. Since ptest is included in the
distro features any ptest sub-pkg RDEPENDS would be installed in the
images despite the ptest sub-pkg itself not actually being included in
the image, since this feature includes any -dev pkg which is built and
the -dev pkg always depends on the main pkg.

Building with this change to your local.conf has no effect on the
runtime as far as I can tell, nor should it be expected.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>