### PR TITLE
overc-conftools: Replace service exit FAILURE with a Note when there …

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/overc-conftools.service
+++ b/meta-cube/recipes-support/overc-conftools/source/overc-conftools.service
@@ -7,7 +7,7 @@ Before=lxc.service
 Type=forking
 Environment=FACTER_ipaddress="192.168.42.2"
 #Only run on first boot and if RPM db has changed
-ExecStart=/bin/sh -c "[ /var/lib/rpm/Packages -nt /var/lib/rpm/overc-conf_run ] && /usr/bin/ansible-playbook /etc/overc-conf/ansible/overc.yml && cp --attributes-only -p /var/lib/rpm/Packages /var/lib/rpm/overc-conf_run"
+ExecStart=/bin/sh -c "[ /var/lib/rpm/Packages -nt /var/lib/rpm/overc-conf_run ] && /usr/bin/ansible-playbook /etc/overc-conf/ansible/overc.yml && cp --attributes-only -p /var/lib/rpm/Packages /var/lib/rpm/overc-conf_run || echo 'No RPM package change!'"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…is no rpm change

When the system does not boot at first time or there is no any rpm package change,
overc-conftools systemd service will always exit with a FAILURE. It is a bad OOBE.
So only print "No RPM package change!" information to replace the exit with a FAILURE.

The overc-conftools systemd service boot failure information is as following:
==========================================================================================
* overc-conftools.service - OverC puppet system configuration
   Loaded: loaded (/lib/systemd/system/overc-conftools.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Mon 2017-07-24 07:28:50 UTC; 2min 8s ago
  Process: 659 ExecStart=/bin/sh -c [ /var/lib/rpm/Packages -nt /var/lib/rpm/puppet_run ] && /usr/bin/puppet apply /etc/puppet/manifests/site.pp && cp --attributes-only -p /var/lib/rpm/Packages /var/lib/rpm/puppet_run (code=exited, status=1/FAILURE)

Jul 24 07:28:50 cube-essential systemd[1]: Starting OverC puppet system configuration...
Jul 24 07:28:50 cube-essential systemd[1]: overc-conftools.service: Control process exited, code=exited status=1
Jul 24 07:28:50 cube-essential systemd[1]: Failed to start OverC puppet system configuration.
Jul 24 07:28:50 cube-essential systemd[1]: overc-conftools.service: Unit entered failed state.
Jul 24 07:28:50 cube-essential systemd[1]: overc-conftools.service: Failed with result 'exit-code'.

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>