### PR TITLE
overc-system-agent: Fix QA errors for python

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory_clean.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory_clean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 
 import sys, os
 import subprocess

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/overc
@@ -1,4 +1,4 @@
-#!/usr/bin/python -Es
+#!/usr/bin/python3 -Es
 # Copyright (C) 2015-2016 WindRiver
 # AUTHOR: Fupan Li <fupan.li@windriver.com>, Amy Fong <amy.fong@windriver.com>
 #

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/run_server.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/run_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys, getopt
 import Overc

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/setup.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Author: Fupan Li <fupan.li@windriver.com>, Amy Fong <amy.fong@windriver.com>
 import os


### PR DESCRIPTION
The overc-system-agent should be using python3 so as to fix this
problem reported by bitbake:

ERROR: overc-system-agent-1.2-r0 do_package_qa: QA Issue:
/opt/overc-system-agent/factory_clean.py contained in package
overc-system-agent requires /usr/bin/python, but no providers found in
RDEPENDS_overc-system-agent? [file-rdeps]

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>