### PR TITLE
xterm: Remove bbappend

### DIFF
--- a/meta-cube/recipes-graphics/xorg-app/xterm_327.bbappend
+++ b/meta-cube/recipes-graphics/xorg-app/xterm_327.bbappend
@@ -1,1 +1,0 @@
-FILES_${PN} += "/usr/lib/X11"


### PR DESCRIPTION
The the fix is now integrated upstream in meta-openembedded commit
471cd564fd72a34ac62f702fad8983f44e4b411a.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>