### PR TITLE
etcd: Allow to build on 32 bit intel architectures

### DIFF
--- a/meta-cube/recipes-connectivity/etcd/etcd_git.bb
+++ b/meta-cube/recipes-connectivity/etcd/etcd_git.bb
@@ -65,6 +65,11 @@ do_compile() {
 	export LDFLAGS=""
 	export CGO_CFLAGS="${BUILDSDK_CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
 	export CGO_LDFLAGS="${BUILDSDK_LDFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+	if [ "${TARGET_ARCH}" = "x86_64" ]; then
+		export GOARCH="amd64"
+	elif [ "${TARGET_ARCH}" = "i586" ]; then
+		export GOARCH="386"
+	fi
 
 	./build
 }


### PR DESCRIPTION
Fix: ERROR: etcd-3.1+gitAUTOINC+99639186cd-r0 do_package_qa: QA Issue:
Architecture did not match (x86-64, expected x86) on
/work/i586-nlp-32-wrs-linux/etcd/3.1+gitAUTOINC+99639186cd-r0/packages-split/etcd-dbg/usr/bin/.debug/etcd

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>