### PR TITLE
upower: upstream 0.99.5 version has fixed this issue.

### DIFF
--- a/meta-cube/recipes-support/upower/upower_0.99.4.bbappend
+++ b/meta-cube/recipes-support/upower/upower_0.99.4.bbappend
@@ -1,3 +1,0 @@
-inherit systemd
-
-SYSTEMD_SERVICE_${PN} = "upower.service"


### PR DESCRIPTION
The upstream latest 0.99.5 version has included this fix. So need to
remove this bbappend to avoid the mismatch recipes version issue.

meta-overc build with the latest meta-openembedded layer will report
the following WARNING:
====================================================================
WARNING: No recipes available for:
  meta-overc/meta-cube/recipes-support/upower/upower_0.99.4.bbappend

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>