### PR TITLE
meta-overc: install kernel-image to cube-essential specifically

### DIFF
--- a/meta-cube/recipes-core/images/cube-essential_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.2.bb
@@ -32,6 +32,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 		  netns \
                   jq \
                   ${CUBE_ESSENTIAL_EXTRA_INSTALL} \
+		  kernel-image \
                  "
 
 # temp. rpm bug workaround


### PR DESCRIPTION
The latest oe-core commit
5dd7ddb66a6<kernel-module-split: rrecommend kernel-image instead of rdepend>
had cut off the dependency between kernel-module and kernel-image, thus
it's needed to install kernel-image specifically, otherwise it wouldn't be
installed into the image.

Signed-off-by: Fupan Li <fupan.li@windriver.com>