### PR TITLE
overc: add ima support to launch dom0 and cube-*

### DIFF
--- a/meta-cube/recipes-support/essential-init/files/essential-autostart
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart
@@ -22,11 +22,13 @@ for container in ${container_names}; do
     # TODO: add non pflask launches ...
     if [ -e "${container_dir}/${container}/pflask.cmd" ]; then
 	# pflask launch
+	# pflask.cmd is not signed by IMA key, so we use "/bin/bash pflask.cmd" rather than
+	# calling pflask.cmd directly to work around IMA checking
 	if [ -n "${single_launch}" ]; then
-	    ${container_dir}/${container}/pflask.cmd
+	    /bin/bash ${container_dir}/${container}/pflask.cmd
 	else
 	    rm -f /tmp/${container}-console
-	    dtach -n /tmp/${container}-console ${container_dir}/${container}/pflask.cmd
+	    dtach -n /tmp/${container}-console /bin/bash ${container_dir}/${container}/pflask.cmd
 	fi
     fi
 done

--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -433,7 +433,8 @@ graft_binaries_to_essential()
 		echo "ERROR: binary ${b} not found"
 		continue
 	    fi
-	    cp ${bin} /var/lib/cube/essential/sbin/
+	    # Copy it in archive mode to include extend attributes used for IMA
+	    cp -af ${bin} /var/lib/cube/essential/sbin/
 	fi
     done
 }
@@ -753,7 +754,9 @@ case "${cmd}" in
 	    *.tar*)
 		echo "[INFO] Installing container ${container_name} to ${out_dir}/${container_name}"
 		echo "[INFO] Extracting rootfs....."
-		tar --numeric-owner -xf ${container_source} -C ${out_dir}/${container_name}/rootfs
+		tar --numeric-owner --warning=no-timestamp \
+		    --xattrs --xattrs-include=security\\.ima \
+		    -xf ${container_source} -C ${out_dir}/${container_name}/rootfs
 		if [ $? != 0 ]; then
 		    echo "[ERROR]: rootfs file extraction failed"
 		    exit 1
@@ -1256,7 +1259,9 @@ case "${cmd}" in
 				tweak_container_fstab ${container_dir}/${container}/rootfs
 				tweak_container_devices ${container} ${container_dir}
 
-				nsenter -P -t 1 -p -n -u -m -C /opt/container/${container}/oci.cmd
+				# oci.cmd is created dynamically at install time without IMA signature.
+				# So we can't run it directly, use "/bin/bash oci.cmd" to work around IMA checking
+				nsenter -P -t 1 -p -n -u -m -C /bin/bash /opt/container/${container}/oci.cmd
 				# TODO: move this cube-cfg call into a pre-start hook, same with the
 				#       delete of the key
 				machine=$(cube-cfg id)


### PR DESCRIPTION
We use pflask.cmd and oci.cmd to start dom0 and cube-*.

The two launch scripts are created by installer, and there is no IMA
private key inside the installer, thus they don't have IMA signatures.

For IMA enabled system, based on our IMA policy, all excutive bianries,
scripts, libraries can't run without IMA signature, so system will deny
to run pflask.cmd or oci.cmd. But /bin/bash is signed by IMA key, and it
is legal to run the scripts like "/bin/bash pflask.cmd/oci.cmd".

Since we can not create pflask.cmd/oci.cmd at build time, this commit
can work around IMA checking during container launch.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>