### PR TITLE
nets, skopeo, umoci, dockerclient: go.bbclass compile fixes

### DIFF
--- a/meta-cube/recipes-containers/netns/netns_git.bbappend
+++ b/meta-cube/recipes-containers/netns/netns_git.bbappend
@@ -1,6 +1,6 @@
 do_install_append() {
 	install -d ${D}/${libexecdir}/oci/hooks.d/
-	install ${S}/netns ${D}/${libexecdir}/oci/hooks.d/netns
+	install ${S}/src/import/netns ${D}/${libexecdir}/oci/hooks.d/netns
 }
 
 FILES_${PN} += "${libexecdir}/oci/hooks.d/"

--- a/meta-cube/recipes-containers/skopeo/skopeo_git.bb
+++ b/meta-cube/recipes-containers/skopeo/skopeo_git.bb
@@ -1,7 +1,7 @@
 HOMEPAGE = "https://github.com/projectatomic/skopeo"
 SUMMARY = "Work with remote images registries - retrieving information, images, signing content"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=7e611105d3e369954840a6668c438584"
+LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=7e611105d3e369954840a6668c438584"
 
 DEPENDS = "\
            go-urfave \
@@ -49,6 +49,7 @@ RDEPENDS_${PN} = "gpgme \
 SRC_URI = "git://github.com/projectatomic/skopeo"
 SRCREV = "f89bd82dcd05a8e09b770bac00d5731c33db5cb1"
 PV = "v0.1.19-dev+git${SRCPV}"
+GO_IMPORT = "import"
 
 S = "${WORKDIR}/git"
 
@@ -68,11 +69,11 @@ do_compile() {
 	#
 	# We also need to link in the ipallocator directory as that is not under
 	# a src directory.
-	ln -sfn . "${S}/vendor/src"
-	mkdir -p "${S}/vendor/src/github.com/projectatomic/skopeo"
-	ln -sfn "${S}/skopeo" "${S}/vendor/src/github.com/projectatomic/skopeo"
-	ln -sfn "${S}/version" "${S}/vendor/src/github.com/projectatomic/skopeo/version"
-	export GOPATH="${S}/vendor"
+	ln -sfn . "${S}/src/import/vendor/src"
+	mkdir -p "${S}/src/import/vendor/src/github.com/projectatomic/skopeo"
+	ln -sfn "${S}/src/import/skopeo" "${S}/src/import/vendor/src/github.com/projectatomic/skopeo"
+	ln -sfn "${S}/src/import/version" "${S}/src/import/vendor/src/github.com/projectatomic/skopeo/version"
+	export GOPATH="${S}/src/import/vendor"
 
 	# Pass the needed cflags/ldflags so that cgo
 	# can find the needed headers files and libraries
@@ -81,6 +82,7 @@ do_compile() {
 	export LDFLAGS=""
 	export CGO_CFLAGS="${BUILDSDK_CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
 	export CGO_LDFLAGS="${BUILDSDK_LDFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+	cd ${S}/src/import
 
 	oe_runmake binary-local
 }
@@ -89,8 +91,8 @@ do_install() {
 	install -d ${D}/${sbindir}
 	install -d ${D}/${sysconfdir}/containers
 
-	install ${S}/skopeo ${D}/${sbindir}/
-	install ${S}/default-policy.json ${D}/${sysconfdir}/containers/policy.json
+	install ${S}/src/import/skopeo ${D}/${sbindir}/
+	install ${S}/src/import/default-policy.json ${D}/${sysconfdir}/containers/policy.json
 }
 
 INSANE_SKIP_${PN} += "ldflags"

--- a/meta-cube/recipes-containers/umoci/umoci_git.bb
+++ b/meta-cube/recipes-containers/umoci/umoci_git.bb
@@ -12,6 +12,7 @@ SRC_URI = "git://github.com/openSUSE/umoci;branch=master;name=umoci;destsuffix=g
 
 PV = "v0.1.0-dev+git${SRCPV}"
 S = "${WORKDIR}/git/src/github.com/openSUSE/umoci"
+GO_IMPORT = "github.com/openSUSE/umoci"
 
 inherit goarch
 inherit go
@@ -31,6 +32,7 @@ do_compile() {
 	export LDFLAGS=""
 	export CGO_CFLAGS="${BUILDSDK_CFLAGS} --sysroot=${STAGING_DIR_TARGET}"
 	export CGO_LDFLAGS="${BUILDSDK_LDFLAGS} --sysroot=${STAGING_DIR_TARGET}"
+	cd ${S}
 
 	oe_runmake umoci
 }

--- a/meta-cube/recipes-devtools/go/dockerclient_git.bb
+++ b/meta-cube/recipes-devtools/go/dockerclient_git.bb
@@ -1,11 +1,12 @@
 SUMMARY = "Go client for the Docker remote API."
 HOMEPAGE = "https://github.com/fsouza/go-dockerclient"
 LICENSE = "BSD-2-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=9687fb4c7ee49afa7b6afd459d1f7169"
+LIC_FILES_CHKSUM = "file://src/import/LICENSE;md5=9687fb4c7ee49afa7b6afd459d1f7169"
 
 PKG_NAME = "github.com/fsouza/go-dockerclient"
 SRC_URI = "git://${PKG_NAME}.git"
 SRCREV = "7e2450a717e8725de58dc1530218cd64117861b3"
+GO_IMPORT = "import"
 
 inherit go
 


### PR DESCRIPTION
Recently in the oe-core the go.bbclass changed and requires the
defition of the GO_IMPORT variable.  This was intended to simplify how
the compilation works with go packages and it is still a work in
progress.

This patch set makes the recipes compatible to generate the same end
result as before using the new go.bbclass from oe-core.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>