### PR TITLE
gnome-keyring: Remove black lists

### DIFF
--- a/conf/distro/overc.conf
+++ b/conf/distro/overc.conf
@@ -122,6 +122,3 @@ ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la perms \
             packages-list perm-config perm-line perm-link pkgv-undefined \
             pn-overrides split-strip var-undefined version-going-backwards"
 
-# Build gnome-keyring
-PNBLACKLIST[gnome-keyring] = ""
-PNBLACKLIST[gcr] = "Incompatible with gnome-keyring"


### PR DESCRIPTION
The meta-openembedded recipe is now repaired upstream.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>