### PR TITLE
meta-overc: fix the issue of dom0 cannot startup at the first time

### DIFF
--- a/meta-cube/recipes-support/essential-init/files/essential-autostart.service
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Essential Autoboot Code
 After=syslog.target network.target
-After=dbus.service
+After=dbus.service overc-conftools.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
The essential-autostart.service should be after overc-conftools.service
since the overc-conftools.service will setup OVS which is needed
by dom0 container.

Signed-off-by: Fupan Li <fupan.li@windriver.com>