### PR TITLE
essential-init: essential-autostart: fix system hang issue

### DIFF
--- a/meta-cube/recipes-support/essential-init/files/essential-autostart.service
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Essential Autoboot Code
 After=syslog.target network.target
-After=dbus.service overc-conftools.service
+After=dbus.service overc-conftools.service systemd-machined.service
 
 [Service]
 Type=forking
 RemainAfterExit=no
 ExecStart=-/usr/sbin/essential-autostart
+# Container dom0 ignores SIGTERM
+ExecStop=-/bin/machinectl kill -s KILL dom0
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
essential-autostart service have to run after systemd-machined, to be
able to register/terminate dom0 to systemd-machined, also, we now call
machinectl to kill dom0 in ExecStop since the dom0 container ignores
SIGTERM, which leads system to hang up to 90Secs.

Signed-off-by: Ming Liu <ming.liu@windriver.com>