### PR TITLE
ostree: inherit autotools-brokensep instead of autotools

### DIFF
--- a/meta-cube/recipes-support/ostree/ostree_git.bb
+++ b/meta-cube/recipes-support/ostree/ostree_git.bb
@@ -14,7 +14,7 @@ SRCREV = "5a5e465492aca13937dab7a2df39f25da94e6e36"
 PV = "2017.8+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-inherit autotools pkgconfig systemd gobject-introspection
+inherit autotools-brokensep pkgconfig systemd gobject-introspection
 
 DEPENDS = " \
     glib-2.0 libsoup-2.4 gpgme e2fsprogs \


### PR DESCRIPTION
Autotools class for ostree recipe where separates build dir doesn't
work well, we have observed quite a few parellel compilation issues, so
we change it to inherit autotools-brokensep instead, which probably can
fix those issues, and this is also how autotools is being used in
ostree recipe of meta-updater project.

Signed-off-by: Ming Liu <ming.liu@windriver.com>