### PR TITLE
Fix parameters for cube-cfg show

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-cfg
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cfg
@@ -803,8 +803,10 @@ case "${cmd}" in
 	clean_config_artifacts
 	;;
     show)
+	container_name=${cmd_options_non_dashed[1]}
 	if [ -z "${container_name}" ]; then
 	    echo "[ERROR]: a container name must be provided"
+	    exit 1
 	fi
 	show_config_artifacts ${container_name}
 	;;


### PR DESCRIPTION
The cube-cfg show command accepts a container name as an argument.

The current code assumes that the container name is passed in via the -n
option.

This fixes the code to match the help text and adds an early exit if
no container name is specified.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>