### PR TITLE
systemd: Work around udev requiring a devtmpfs mount

### DIFF
--- a/meta-cube/recipes-core/systemd/systemd/create_block_devs_containers.patch
+++ b/meta-cube/recipes-core/systemd/systemd/create_block_devs_containers.patch
@@ -1,0 +1,16 @@
+---
+ rules/50-udev-default.rules.in |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/rules/50-udev-default.rules.in
++++ b/rules/50-udev-default.rules.in
+@@ -53,7 +53,8 @@ KERNEL=="lp[0-9]*", GROUP="lp"
+ KERNEL=="irlpt[0-9]*", GROUP="lp"
+ SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:0701??:*", GROUP="lp"
+ 
+-SUBSYSTEM=="block", GROUP="disk"
++# if /dev is not devtmpfs, work around it by creating the device that is required for hotplug
++SUBSYSTEM=="block", GROUP="disk", IMPORT{program}="/bin/sh -c 'if [ ! -e %N ] ; then /bin/mknod %N b %M %m; fi'"
+ SUBSYSTEM=="block", KERNEL=="sr[0-9]*", GROUP="cdrom"
+ SUBSYSTEM=="scsi_generic", SUBSYSTEMS=="scsi", ATTRS{type}=="4|5", GROUP="cdrom"
+ KERNEL=="sch[0-9]*", GROUP="cdrom"

--- a/meta-cube/recipes-core/systemd/systemd_234.bbappend
+++ b/meta-cube/recipes-core/systemd/systemd_234.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
         file://0001-systemd-make-udev-create-or-delete-device-nodes.patch \
 	file://OverC_Allow_RW_sys.patch \
+	file://create_block_devs_containers.patch \
        "
 
 # Temporary patch until runc can be fixed properly to deal with EPOLLHUP


### PR DESCRIPTION
When using containers the /dev directory is a private tmpfs by
default.  The udev rules have an implicit assumption that /dev is
mounted as a devtmpfs where the kernel auto instantiates a device node
prior to issuing a uevent notification via the sysfs.

If you turn on logging for systemd-udev as follows you can see the problem:

echo 'udev_log="debug"' >> /etc/udev/udev.conf
systemctl restart systemd-udevd

Now in the system journal if you have a USB hotplug even it the
following error will show up:

Oct 19 10:05:18 localhost systemd-udevd[535]: starting 'ata_id --export /dev/sda'
Oct 19 10:05:18 localhost ata_id[535]: unable to open '/dev/sda'
Oct 19 10:05:18 localhost systemd-udevd[534]: Process 'ata_id --export /dev/sda' failed with exit code 1.

This is because the udev rules assume /dev/sda was auto instantiated by the devtmpfs.

The solution is to check for, and create if missing the device node in
the default rule template via an import{program} rule.  This will run
immediately prior to running any of the rule templates that have the
implicit assumptions.  No changes are needed to the hot plug services
because udev will issue the rest of the events normally so long as the
device node exists initially.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>