### PR TITLE
cube-ctl: Fix state problem where container cannot be restarted

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1545,10 +1545,7 @@ IFS=$OLDIFS
 	    echo ${open_container_running} | grep -q ${container_name}
 	    if [ $? -eq 0 ]; then
 		echo "[INFO] stopping container ${container_name}"
-		cube-cmd ${runc_essential} kill ${container_name} KILL
-		if [ "${cmd}" == "stop" ]; then
-		    cube-cmd ${runc_essential} delete ${container_name}
-		fi
+		cube-cmd ${runc_essential} delete -f ${container_name}
 		machine=$(cube-cfg id)
 		cube-cfg set overc/$machine/oci/${container_name}/status:inactive
 	    else


### PR DESCRIPTION
Sometimes when the container is stopped the delete operation cannot be
processed immediately because the container state updates are not
fully synced yet.  Example:

    root@cube-dom0:/usr/sbin# c3 stop cube-desktop
    [INFO] stopping container cube-desktop
    cannot delete container cube-desktop that is not stopped: running

The latest oci runtime now allows the delete operation to forcefully
kill the container so that it can be terminated in one step reliably,
so we will switch to using it instead of implementing a check for the
state to change prior to initiating the delete.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>