### PR TITLE
cube-ctl: Fix state problem where container cannot be restarted

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1547,7 +1547,7 @@ IFS=$OLDIFS
 		echo "[INFO] stopping container ${container_name}"
 		cube-cmd ${runc_essential} kill ${container_name} KILL
 		if [ "${cmd}" == "stop" ]; then
-		    cube-cmd ${runc_essential} delete ${container_name}
+		    cube-cmd ${runc_essential} delete -f ${container_name}
 		fi
 		machine=$(cube-cfg id)
 		cube-cfg set overc/$machine/oci/${container_name}/status:inactive


### PR DESCRIPTION
Sometimes when the container is stopped the delete operation cannot be
processed immediately because the container state updates are not
fully synced yet.  Example:

    root@cube-dom0:/usr/sbin# c3 stop cube-desktop
    [INFO] stopping container cube-desktop
    cannot delete container cube-desktop that is not stopped: running

The latest oci runtime has added a -f argument to the delete command
which will send a signal and wait.  In the case that signal was
already received it still waits until the conatiner is actually
stopped and then purges the configuration.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>