### PR TITLE
Back to work

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -154,8 +154,6 @@ IMAGE_FSTYPES_remove = "wic wic.bmap"
 
 #IMAGE_FEATURES += "splash ssh-server-openssh hwcodecs package-management"
 IMAGE_FEATURES += "ssh-server-openssh package-management"
-# do not install recommendations
-NO_RECOMMENDATIONS = "1"
 
 #
 # Extra image configuration defaults

--- a/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
@@ -24,6 +24,7 @@ PACKAGES = "\
      packagegroup-dom0-perl \
      packagegroup-dom0-python \
      packagegroup-dom0-tools \
+     packagegroup-dom0-only \
     "
 
 RDEPENDS_packagegroup-dom0 = "\
@@ -34,6 +35,7 @@ RDEPENDS_packagegroup-dom0 = "\
      packagegroup-dom0-perl \
      packagegroup-dom0-python \
      packagegroup-dom0-tools \
+     packagegroup-dom0-only \
     "
 
 RDEPENDS_packagegroup-dom0-fs = " \
@@ -66,4 +68,8 @@ RDEPENDS_packagegroup-dom0-networking = "\
 RDEPENDS_packagegroup-dom0-tools = "\
      ${OVERC_COMMON_TOOLS} \
      container-shutdown-notifier \
+    "
+
+RDEPENDS_packagegroup-dom0-only = "\
+     linux-firmware \
     "

--- a/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
@@ -44,6 +44,6 @@ RDEPENDS_packagegroup-essential-networking = "\
     "
 
 RDEPENDS_packagegroup-essential-only = "\
-     linux-firmware \
+     linux-firmware-cube-shared \
      watchdog \
     "

--- a/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,0 +1,16 @@
+PACKAGES += "${PN}-cube-shared"
+
+DESCRIPTION_${PN}-cube-shared = "Creates a link for /lib/firmware to \
+/var/lib/cube/essential/lib/firmware. This is intended to be used in \
+conjunction with dom0-ctl-core. This package is only effective if no \
+other linux-firmware(-*) packages are installed."
+
+ALLOW_EMPTY_${PN}-cube-shared = "1"
+
+pkg_postinst_${PN}-cube-shared () {
+    # Be a nop if any other linux-firmware(-*) pkgs are found
+    if [ ! -e $D/lib/firmware ]; then
+        mkdir -p $D/var/lib/cube/essential/lib/firmware
+        ln -sfr $D/var/lib/cube/essential/lib/firmware $D/lib/firmware
+    fi
+}

--- a/meta-cube/recipes-support/dom0-init/dom0-init_1.0.bb
+++ b/meta-cube/recipes-support/dom0-init/dom0-init_1.0.bb
@@ -9,6 +9,7 @@ RDEPENDS_${PN} = "overc-utils util-linux bash"
 SRC_URI = "file://dom0-containers \
            file://dom0-ctl-core.service \
            file://dom0-ctl-core.conf \
+           file://firmware-sync \
 "
 
 SRC_FILES_LIST="dom0-containers \
@@ -43,6 +44,9 @@ do_install() {
 
     install -d ${D}/${sysconfdir}
     install -m 0744 ${WORKDIR}/dom0-ctl-core.conf ${D}/${sysconfdir}
+
+    install -d ${D}/${sysconfdir}/dom0.d
+    install -m 0770 ${WORKDIR}/firmware-sync ${D}/${sysconfdir}/dom0.d/
 }
 
 FILES_${PN} += "${sbin} \

--- a/meta-cube/recipes-support/dom0-init/files/dom0-ctl-core.service
+++ b/meta-cube/recipes-support/dom0-init/files/dom0-ctl-core.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=forking
 RemainAfterExit=yes
 # ExecStartPre=
-# ExecStartPre=
+ExecStartPre=/etc/dom0.d/firmware-sync
 ExecStart=/usr/sbin/dom0-containers start
 ExecStop=/usr/sbin/dom0-containers stop
 # Environment=BOOTUP=serial

--- a/meta-cube/recipes-support/dom0-init/files/firmware-sync
+++ b/meta-cube/recipes-support/dom0-init/files/firmware-sync
@@ -1,0 +1,44 @@
+#!/bin/bash
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+if [ "$CUBE_DEBUG_SET_X_IF_SET" = 1 ] ; then
+    set -x
+fi
+
+container_dir="/opt/container"
+
+# Copy /lib/firmware from dom0 to /var/lib/cube/essential
+# This allows for firmware to be upgraded by updating dom0
+refresh_cube_essential_firmware()
+{
+    local dom0_rootfs="${container_dir}/dom0/rootfs"
+
+    if [ ! -d "/var/lib/cube/essential/lib/firmware/" ]; then
+	mkdir -p "/var/lib/cube/essential/lib/firmware/"
+    fi
+
+    # Ensure copy matches dom0 /lib/firmware, avoiding unnecessary
+    # copying. This may or may not save time but will avoid
+    # possible wear on the media and avoids having rsync available.
+    while read -r delta; do
+	if [[ $delta = "Only in ${dom0_rootfs}/lib/firmware/:"* ]]; then
+	    filename=$(echo ${delta} | awk -F': ' '{print $NF}')
+	    cp ${dom0_rootfs}/lib/firmware/${filename} /var/lib/cube/essential/lib/firmware/
+	elif [[ $delta = "Only in /var/lib/cube/essential/lib/firmware/:"* ]]; then
+	    filename=$(echo ${delta} | awk -F': ' '{print $NF}')
+	    rm -f /var/lib/cube/essential/lib/firmware/${filename}
+	elif [[ $delta = Files*and*differ ]]; then
+	    cmd=$(echo ${delta} | sed 's/^Files/cp/' | sed 's/\ differ$//' | sed 's/\ and\ / /')
+	    $(exec $cmd)
+	fi
+    done <<< "$(/usr/bin/diff -qr ${dom0_rootfs}/lib/firmware/ /var/lib/cube/essential/lib/firmware/)"
+}
+
+refresh_cube_essential_firmware


### PR DESCRIPTION
2 Changes.

1) A resend of my work to use the firmware from -dom0.

2) A new commit which fixes a deficiency in the local.conf sample. I couldn't find sufficient documentation as to why we had the NO_RECOMMENDS in place and it is demonstrably failing with cube-desktop. If you have something that shows it should be in place I am open to being wrong on this but on the face of it I believe it is just wrong and should be removed from our sample local.conf.