### PR TITLE
Back to work V3

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -154,8 +154,6 @@ IMAGE_FSTYPES_remove = "wic wic.bmap"
 
 #IMAGE_FEATURES += "splash ssh-server-openssh hwcodecs package-management"
 IMAGE_FEATURES += "ssh-server-openssh package-management"
-# do not install recommendations
-NO_RECOMMENDATIONS = "1"
 
 #
 # Extra image configuration defaults

--- a/docs/README.firmware
+++ b/docs/README.firmware
@@ -1,0 +1,78 @@
+Shared Firmware
+-------------------------
+
+Since one of the goals for cube-essential is to keep a small
+footprint, the kernel firmware files pose a specific challenge. The
+/lib/firmware directory amounts to about half the total size of the
+cube-essential image. With such a large portion of the image being
+firmware, many updates to cube-essential could be triggered by the
+need to update firmware (yes the # of updates isn't proportional to
+the size ratio but it is also non-zero).
+
+With the above in mind it was determined that sharing firmware with
+dom0 we can perform firmware updates without ever having to update
+cube-essential. Firmware updates can be made in dom0 and the result
+will be shared with cube-essential.
+
+
+Filesystem changes
+-------------------------
+
+cube-essential
+---
+In cube-essential '/lib/firmware' is no longer populated with firmware
+blobs and associated files/directories. '/lib/firmware' becomes a link
+to '/var/lib/cube/essential/lib/firmware' ('/var/lib/cube/essential'
+being a directory which is visible to dom0 and keeping '/lib/firmware'
+part of the path to make it clear what it is). If you examine
+'/lib/firmware' on cube-essential you will see a typical firmware
+directory, beyond this being a link to another directory.
+
+NOTE: To accomplish the above you can examine the
+linux-firmware-cube-shared package (linux-firmware_git.bbappend)
+
+dom0
+---
+In dom0 you will find a '/lib/firmware' directory populated with
+firmware related files, per usual. You will also find that the
+dom0-ctl-core systemd service has a new 'ExecStartPre' called
+'firmware-sync'. This 'ExecStartPre' will call
+'/etc/dom0.d/firmware-sync' to allow the contents of dom0's
+'/lib/firmware' directory to be 'copied' to
+'/var/lib/cube/essential/lib/firmware', such that cube-essential will
+end up with a matching copy of the firmware in its '/lib/firmware'
+directory (link).
+
+NOTE: The 'copy' is a one direction sync from dom0 to cube-essential,
+additions/removals in dom0's '/lib/firmware' will be reflected in
+cube-essential's '/lib/firmware' after a sync, but not the other way
+around.
+
+
+Syncing
+-------------------------
+
+Updating the cube-essential firmware now involves different steps than
+you would find in the traditional model. A typical update now might
+look like one of the following:
+
+1)
+  a) replace dom0 (with the new image containing '/lib/firmware' updates)
+  b) restart dom0 (the dom0-ctl-core will automatically sync firmware)
+  c) reload cube-essential kernel modules affected by firmware updates
+
+2)
+  a) update dom0 (with firmware related package updates)
+  b) run '/etc/dom0.d/firmware-sync' to complete a sync
+  c) reload cube-essential kernel modules affected by firmware updates
+
+3)
+  a) update or replace dom0 (including firmware updates)
+  b) run '/etc/dom0.d/firmware-sync' to complete a sync
+  c) reboot the system
+
+NOTE that it may not always be possible to complete an update, which
+includes firmware updates, without having to perform a system
+reboot. This change doesn't change this but rather provides additional
+options to the system designer that can often avoid a system reboot in
+most cases.

--- a/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
@@ -24,6 +24,7 @@ PACKAGES = "\
      packagegroup-dom0-perl \
      packagegroup-dom0-python \
      packagegroup-dom0-tools \
+     packagegroup-dom0-only \
     "
 
 RDEPENDS_packagegroup-dom0 = "\
@@ -34,6 +35,7 @@ RDEPENDS_packagegroup-dom0 = "\
      packagegroup-dom0-perl \
      packagegroup-dom0-python \
      packagegroup-dom0-tools \
+     packagegroup-dom0-only \
     "
 
 RDEPENDS_packagegroup-dom0-fs = " \
@@ -66,4 +68,8 @@ RDEPENDS_packagegroup-dom0-networking = "\
 RDEPENDS_packagegroup-dom0-tools = "\
      ${OVERC_COMMON_TOOLS} \
      container-shutdown-notifier \
+    "
+
+RDEPENDS_packagegroup-dom0-only = "\
+     linux-firmware \
     "

--- a/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
@@ -44,6 +44,6 @@ RDEPENDS_packagegroup-essential-networking = "\
     "
 
 RDEPENDS_packagegroup-essential-only = "\
-     linux-firmware \
+     linux-firmware-cube-shared \
      watchdog \
     "

--- a/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,0 +1,16 @@
+PACKAGES += "${PN}-cube-shared"
+
+DESCRIPTION_${PN}-cube-shared = "Creates a link for /lib/firmware to \
+/var/lib/cube/essential/lib/firmware. This is intended to be used in \
+conjunction with dom0-ctl-core. This package is only effective if no \
+other linux-firmware(-*) packages are installed."
+
+ALLOW_EMPTY_${PN}-cube-shared = "1"
+
+pkg_postinst_${PN}-cube-shared () {
+    # Be a nop if any other linux-firmware(-*) pkgs are found
+    if [ ! -e $D/lib/firmware ]; then
+        mkdir -p $D/var/lib/cube/essential/lib/firmware
+        ln -sfr $D/var/lib/cube/essential/lib/firmware $D/lib/firmware
+    fi
+}

--- a/meta-cube/recipes-support/dom0-init/dom0-init_1.0.bb
+++ b/meta-cube/recipes-support/dom0-init/dom0-init_1.0.bb
@@ -9,6 +9,7 @@ RDEPENDS_${PN} = "overc-utils util-linux bash"
 SRC_URI = "file://dom0-containers \
            file://dom0-ctl-core.service \
            file://dom0-ctl-core.conf \
+           file://firmware-sync \
 "
 
 SRC_FILES_LIST="dom0-containers \
@@ -43,6 +44,9 @@ do_install() {
 
     install -d ${D}/${sysconfdir}
     install -m 0744 ${WORKDIR}/dom0-ctl-core.conf ${D}/${sysconfdir}
+
+    install -d ${D}/${sysconfdir}/dom0.d
+    install -m 0770 ${WORKDIR}/firmware-sync ${D}/${sysconfdir}/dom0.d/
 }
 
 FILES_${PN} += "${sbin} \

--- a/meta-cube/recipes-support/dom0-init/files/dom0-ctl-core.service
+++ b/meta-cube/recipes-support/dom0-init/files/dom0-ctl-core.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=forking
 RemainAfterExit=yes
 # ExecStartPre=
-# ExecStartPre=
+ExecStartPre=/etc/dom0.d/firmware-sync
 ExecStart=/usr/sbin/dom0-containers start
 ExecStop=/usr/sbin/dom0-containers stop
 # Environment=BOOTUP=serial

--- a/meta-cube/recipes-support/dom0-init/files/firmware-sync
+++ b/meta-cube/recipes-support/dom0-init/files/firmware-sync
@@ -1,0 +1,46 @@
+#!/bin/bash
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2 as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU General Public License for more details.
+
+if [ "$CUBE_DEBUG_SET_X_IF_SET" = 1 ] ; then
+    set -x
+fi
+
+container_dir="/opt/container"
+
+# Copy /lib/firmware from dom0 to /var/lib/cube/essential
+# This allows for firmware to be upgraded by updating dom0
+refresh_cube_essential_firmware()
+{
+    local dom0_rootfs="${container_dir}/dom0/rootfs"
+
+    if [ ! -d "/var/lib/cube/essential/lib/firmware/" ]; then
+	mkdir -p "/var/lib/cube/essential/lib/firmware/"
+    fi
+
+    # Ensure copy matches dom0 /lib/firmware, avoiding unnecessary
+    # copying. This may or may not save time but will avoid
+    # possible wear on the media and avoids having rsync available.
+    while read -r delta; do
+	if [[ $delta = "Only in ${dom0_rootfs}/lib/firmware/"* ]]; then
+	    dir=${delta#*firmware/}; dir=${dir%%:*}/
+	    filename=${delta#*: }
+	    cp -a ${dom0_rootfs}/lib/firmware/${dir}${filename} /var/lib/cube/essential/lib/firmware/${dir}
+	elif [[ $delta = "Only in /var/lib/cube/essential/lib/firmware/"* ]]; then
+	    dir=${delta#*firmware/}; dir=${dir%%:*}/
+	    filename=${delta#*: }
+	    rm -rf /var/lib/cube/essential/lib/firmware/${dir}${filename}
+	elif [[ $delta = Files*and*differ ]]; then
+	    cmd=$(echo ${delta} | sed 's/^Files/cp/' | sed 's/\ differ$//' | sed 's/\ and\ / /')
+	    $(exec $cmd)
+	fi
+    done <<< "$(/usr/bin/diff -qr ${dom0_rootfs}/lib/firmware/ /var/lib/cube/essential/lib/firmware/)"
+}
+
+refresh_cube_essential_firmware


### PR DESCRIPTION
An update to my recent 'Back to work' pull request. This fixes some deficiencies in the firmware sharing code that was causing the service to fail and the cube-desktop from auto running.

The original 2 parts of this pull request remain as described in the commit headers and V1 of this PR.

Fixup the local.conf sample to remove the NO_RECOMMENDATIONS.
Allow firmware to be shared between -Dom0 and -essential

***V3*** 
* Added a README to describe the shared firmware and its use.