### PR TITLE
linux-yocto*: Add cgroups by default

### DIFF
--- a/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -25,6 +25,7 @@ LINUX_VERSION_EXTENSION = "-cube"
 
 KERNEL_FEATURES_append = " features/kvm/qemu-kvm-enable.scc"
 KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
+KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 
 KERNEL_MODULE_AUTOLOAD += "openvswitch"
 KERNEL_MODULE_AUTOLOAD += "kvm"

--- a/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-rt_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI += "file://xt-checksum.scc \
             "
 KERNEL_FEATURES_append = " features/kvm/qemu-kvm-enable.scc"
 KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
+KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 KERNEL_FEATURES_append = " cfg/systemd.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext3.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext2.scc"

--- a/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -12,6 +12,7 @@ SRC_URI += "file://xt-checksum.scc \
 KERNEL_FEATURES_append = " features/kvm/qemu-kvm-enable.scc"
 KERNEL_FEATURES_append = " features/nfsd/nfsd-enable.scc"
 KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
+KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 KERNEL_FEATURES_append = " cfg/systemd.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext3.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext2.scc"


### PR DESCRIPTION
The containers can leverage all the different cgroup controls so long
as they are enabled.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>