### PR TITLE
essential-init: add reload-dom0-snapshot.service

### DIFF
--- a/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
+++ b/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
@@ -8,14 +8,17 @@ RDEPENDS_${PN} = "util-linux bash pflask"
 
 SRC_URI = "file://essential-autostart \
            file://essential-autostart.service \
+           file://reload-dom0-snapshot \
+           file://reload-dom0-snapshot.service \
 "
 
-SRC_FILES_LIST="essential-autostart \
+SRC_FILES_LIST = "essential-autostart \
+                  reload-dom0-snapshot \
 "
 
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "essential-autostart.service"
+SYSTEMD_SERVICE_${PN} = "essential-autostart.service reload-dom0-snapshot.service"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
 systemd_postinst() {
@@ -39,6 +42,7 @@ do_install() {
 
     install -d ${D}/lib/systemd/system/
     install -m 0644 ${WORKDIR}/essential-autostart.service ${D}/lib/systemd/system/
+    install -m 0644 ${WORKDIR}/reload-dom0-snapshot.service ${D}/lib/systemd/system/
 }
 
 FILES_${PN} += "${sbin} \

--- a/meta-cube/recipes-support/essential-init/files/reload-dom0-snapshot
+++ b/meta-cube/recipes-support/essential-init/files/reload-dom0-snapshot
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+container_dir="/opt/container"
+snapshots_dir="/opt/container/.snapshots"
+snapshot=$(cat ${snapshots_dir}/dom0/.need_reload 2>/dev/null)
+
+# Sanity check
+if [ -z "${snapshot}" -o ! -d ${snapshots_dir}/dom0/${snapshot} ]; then
+        echo "[ERROR]: The required snapshot is not available."
+        exit 1
+    fi
+
+# Delete all subvolumes recursively in reverse order
+subvols=$(btrfs subvolume list -o ${container_dir}/dom0 | awk '{print $NF}' | sed "s#workdir#${container_dir}/dom0#")
+for subvol in $(echo ${subvols} | tr ' ' '\n' | tac | tr '\n' ' '); do
+        btrfs subvolume delete -C ${subvol}
+done
+
+btrfs subvolume delete -C ${container_dir}/dom0
+btrfs subvolume snapshot ${snapshots_dir}/dom0/${snapshot} ${container_dir}/dom0
+btrfs subvolume delete -C ${snapshots_dir}/dom0/${snapshot}
+sed -i "/${snapshot}/d" ${snapshots_dir}/dom0/.container_history
+rm ${snapshots_dir}/dom0/.need_reload
+exit 0

--- a/meta-cube/recipes-support/essential-init/files/reload-dom0-snapshot.service
+++ b/meta-cube/recipes-support/essential-init/files/reload-dom0-snapshot.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reload dom0 snapshot if needed
+After=syslog.target
+Before=essential-autostart.service
+ConditionPathExists=/opt/container/.snapshots/dom0/.need_reload
+
+[Service]
+Type=forking
+RemainAfterExit=no
+ExecStart=-/usr/sbin/reload-dom0-snapshot
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This service will handle reloading dom0 snapshot if it's detected that
dom0 had been rolled back at the last running time, this service is
needed because dom0 can not reload itself.

When this service starts, it will check a file existence:
/opt/container/.snapshots/dom0/.need_reload

and read the snapshot ID from the file if it exists, or else it will do
nothing.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>