### PR TITLE
essential-autostart.service: Also kill containers on shutdown/reboot/halt

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -23,6 +23,11 @@ cat << EOF
        --auto=<name>: launch autostart containers tagged with <name>
 
        <name>: name of the container to be launched (if not "--auto")
+
+       Startup container debug ONLY options:
+       -f -i  Start interactive container console in foreground on current tty.
+       -f     Start container in foreground on current tty.
+       -a     Attach container console just prior to start on current tty.
 EOF
 }
 


### PR DESCRIPTION

The systemd shutdown service will sometimes hang for 2 minutes if
there are any resources that have not been released.  The dom0 is
responsible for the graceful shutdown of any containers.  If it is to
the point that essential is processing shutdown/reboot/halt any
remaining runc processes need to be SIGKILL'ed so as to avoid any kind
of hang.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>