### PR TITLE
overc-system-agent: factory_clean: clean up all snapshots

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -110,6 +110,9 @@ class Overc(object):
             log.info("rebooting...")
             os.system('reboot')
 
+    def system_cleanup(self):
+        self.agency.clean_essential()
+        self.container_cleanup()
 
     def factory_reset(self):
         rc = self.agency.factory_reset()
@@ -289,6 +292,13 @@ class Overc(object):
     def container_delete_snapshots(self):
         self._container_delete_snapshots(self.args.name, self.args.template)
         sys.exit(self.retval)
+
+    def container_cleanup(self):
+       # TODO: extend this list according to the supported templates
+       templates = ['dom0']
+       for template in templates:
+           for container in self.container.get_container(template):
+               self._container_delete_snapshots(container, template)
 
     def _container_delete_snapshots(self, container, template):
         self.retval = self.container.delete_snapshots(container, template)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory_clean.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory_clean.py
@@ -6,4 +6,4 @@ import Overc
 
 if __name__ == '__main__':
     overc = Overc.Overc()
-    overc.agency.clean_essential()
+    overc.system_cleanup()


### PR DESCRIPTION
Add a system_cleanup function handling cleaning up all the snapshots
after factory reset.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>