### PR TITLE
overc-utils: cube-ctl: remove securityfs out of /etc/fstab

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -593,6 +593,7 @@ tweak_container_fstab()
 	sed -i '/^devpts/d' ${rootfs}/etc/fstab
 	sed -i '/^tmpfs/d' ${rootfs}/etc/fstab
 	sed -i '/^usbdevfs/d' ${rootfs}/etc/fstab
+	sed -i '/^securityfs/d' ${rootfs}/etc/fstab
     fi
 }
 


### PR DESCRIPTION
Containers do not need mount securityfs filesystem, so drop it.
Otherwise, it will cause systemd-remount-fs.service to fail.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>