### PR TITLE
overc-system-agent: fix a typo

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -207,7 +207,7 @@ class Btrfs(Utils):
             self.message += 'Error: Cannot find the snapshot of factory in %s/.tmp' % CONTAINER_MOUNT
             self.message += '\n'
             self.message += 'Factory reset aborted!'
-            os.system('umount %s/.tmp' % CONTAINER_MOUNT)
+            os.system('cube-cmd umount %s/.tmp' % CONTAINER_MOUNT)
             return False
         work_subvol =  self._random_str()   
         workdir = '%s/.tmp/%s' % (CONTAINER_MOUNT, work_subvol)
@@ -216,7 +216,7 @@ class Btrfs(Utils):
             self.message += "Cannot factory reset, please check is there enough diskspace left"
             self.message += '\n'
             self.message += 'Factory reset aborted!'
-            os.system('umount %s/.tmp' % CONTAINER_MOUNT)
+            os.system('cube-cmd umount %s/.tmp' % CONTAINER_MOUNT)
             return False
 
         #snapshot the children subvolumes
@@ -248,7 +248,7 @@ class Btrfs(Utils):
             self.message += "Cannot set default mount subvolume to %s" % workdir
             self.message += '\n'
             self.message += 'Factory reset aborted!'
-            os.system('umount %s/.tmp' % CONTAINER_MOUNT)
+            os.system('cube-cmd umount %s/.tmp' % CONTAINER_MOUNT)
             return False
    
     def _do_upgrade(self, host=False):

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -146,6 +146,12 @@ class Btrfs(Utils):
         self._mount_rootvolume(True)
         self._cleanup_subvol(SYSROOT, [FACTORY_SNAPSHOT, 'rootfs_bakup'], True)
 
+    def clean_container(self):
+        self._mount_container_root(True)
+        current_subvol = self._get_btrfs_value(CONTAINER_MOUNT, 'Name', True)
+        self._cleanup_subvol('%s/.tmp' % CONTAINER_MOUNT, [current_subvol, FACTORY_SNAPSHOT], True)
+        os.system('cube-cmd umount %s/.tmp' % CONTAINER_MOUNT)
+
     def factory_reset(self):
         return self._factory_reset_essential() and self._factory_reset_container() 
 

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -339,7 +339,7 @@ class Btrfs(Utils):
              
     def do_upgrade(self):
             self._mount_rootvolume(True)
-            self._do_upgrade(True)
+            return self._do_upgrade(True)
 
     def do_rollback(self):
         if self.bakup_mode:

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -309,7 +309,7 @@ class Btrfs(Utils):
                 #backup kernel
                 os.system('%scp -f %s  %s_bakup' % (cube_cmd, self.kernel, self.kernel))
                 if self._path_exists(self.kernel + '.p7b', host):
-                    os.system('%cp -f %s.p7b %s_bakup.p7b' % (cube_cmd, self.kernel, self.kernel))
+                    os.system('%scp -f %s.p7b %s_bakup.p7b' % (cube_cmd, self.kernel, self.kernel))
                 os.system('%scp -f %s %s' % (cube_cmd, upgrade_kernel, self.kernel))
                 if self._path_exists(upgrade_kernel + '.p7b', host):
                     os.system('%scp -f %s.p7b %s.p7b' % (cube_cmd, upgrade_kernel, self.kernel))

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -59,6 +59,7 @@ class Overc(object):
 
         # By now only support "Pulsar" and "overc" Linux upgrading
         DIST = "Pulsar overc"
+        succeeded = []
         for cn in containers:
             if self.container.is_active(cn, template):
                 for dist in DIST.split():
@@ -68,11 +69,19 @@ class Overc(object):
                         if self.retval is not 0:
                             log.error("*** Failed to upgrade container %s" % cn)
                             log.error("*** Abort the system upgrade action")
-                            sys.exit(self.retval)
+                            break
                         else:
+                            succeeded.append(cn)
                             if self.container.is_overlay(cn) > 0:
                                 overlay_flag = 1
                         break
+            if self.retval is not 0:
+                break
+
+        if self.retval is not 0:
+            for cn in succeeded:
+                self._container_rollback(cn, None, template, True)
+            sys.exit(self.retval)
 
         rc = self._host_upgrade(0, force)
 
@@ -165,24 +174,25 @@ class Overc(object):
         self._host_upgrade(self.args.reboot, self.args.force)
 
     def _host_upgrade(self, reboot, force):
+        rc = False
         if self._need_upgrade() or force:
-            self.agency.do_upgrade()
+            rc = self.agency.do_upgrade()
             self.message = self.agency.message
         else:
             self.message = "There is no new system available to upgrade!"
             log.info(self.message)
-            return 0
+            return True
 
         if reboot:
             log.info("rebooting...")
             os.system('reboot')
-        return 1
+        return rc
 
     def host_rollback(self):
         if self.bakup_mode:
             self.message = "You are running in the backup mode, cannot do rollback!"
             log.error(self.message)
-            return
+            return False
 
         log.info("Start doing host rollback")
         r = self.agency.do_rollback()
@@ -191,7 +201,7 @@ class Overc(object):
             os.system('reboot')
         else:
             log.error(self.message)
-            return 1
+            return False
         
     def container_rollback(self):
         self._container_rollback(self.args.name, self.args.snapshot_name, self.args.template, True)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -294,11 +294,14 @@ class Overc(object):
         sys.exit(self.retval)
 
     def container_cleanup(self):
-       # TODO: extend this list according to the supported templates
-       templates = ['dom0']
-       for template in templates:
-           for container in self.container.get_container(template):
-               self._container_delete_snapshots(container, template)
+        # clean up temporary snapshots
+        self.agency.clean_container()
+
+        # TODO: extend this list according to the supported templates
+        templates = ['dom0']
+        for template in templates:
+            for container in self.container.get_container(template):
+                self._container_delete_snapshots(container, template)
 
     def _container_delete_snapshots(self, container, template):
         self.retval = self.container.delete_snapshots(container, template)

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory-reset.service
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/factory-reset.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=factory reset post clean up
 After=local-fs.target
+ConditionPathExists=!/etc/overc/.factory-reset.lock
 
 [Service]
 Type=oneshot
 ExecStart=/opt/overc-system-agent/factory_clean.py
 ExecStartPost=/bin/systemctl disable factory-reset.service
+ExecStartPost=/bin/touch /etc/overc/.factory-reset.lock
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A regression was introduced by commit a98ff71b:
[ overc-system-agent: forward port a fix from pulsa8 ]

a 's' was missed which lead to a python TypeError.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>