### PR TITLE
runc shutdown and daemonize stop hooks

### DIFF
--- a/meta-cube/recipes-containers/pflask/pflask/0001-machined-interface-Use-RegisterMachine-instead-of-Cr.patch
+++ b/meta-cube/recipes-containers/pflask/pflask/0001-machined-interface-Use-RegisterMachine-instead-of-Cr.patch
@@ -1,0 +1,60 @@
+From b1d3b7ca677b302d46db70bad18f8aa14820802b Mon Sep 17 00:00:00 2001
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Thu, 30 Nov 2017 07:10:16 -0800
+Subject: [PATCH] machined interface: Use RegisterMachine instead of
+ CreateMachine
+
+The CreateMachine interface is designed for whole containers where
+machined will take over all the cgroups and re-parent all the
+processes in the pflask into a special machine slice managed by
+systemd.  This is particularly problematic if you want to have custom
+shutdown services to gracefully shutdown the system.  In the case of
+dom0 when the root name space is asked to reboot it would start
+signaling dom0's systemd which prevents any kind of graceful shutdown.
+Instead you end up with the dom0 systemd hanging waiting to talk to
+the root name space systemd which is no longer listening.
+
+The RegisterMachine will allow machinectl to operate on a pflask using
+only the pid operations.  The OverC manager will take care of all the
+cgroups and management of the instances.
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+---
+ src/machine.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/machine.c b/src/machine.c
+index ae870e4..f451100 100644
+--- a/src/machine.c
++++ b/src/machine.c
+@@ -70,7 +70,11 @@ void register_machine(pid_t pid, const char *dest, const char *machine_name) {
+ 		"org.freedesktop.machine1",
+ 		"/org/freedesktop/machine1",
+ 		"org.freedesktop.machine1.Manager",
++#if USE_DBUS_CREATE_CONTAINER
+ 		"CreateMachine"
++#else /* ! USE_DBUS_CREATE_CONTAINER */
++		"RegisterMachine"
++#endif /* ! USE_DBUS_CREATE_CONTAINER */
+ 	);
+ 
+ 	dbus_message_iter_init_append(req, &args);
+@@ -107,6 +111,7 @@ void register_machine(pid_t pid, const char *dest, const char *machine_name) {
+ 	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &dest))
+ 		fail_printf("OOM");
+ 
++#if USE_DBUS_CREATE_CONTAINER
+ 	/* scope properties */
+ 	if (!dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "(sv)",
+ 	                                      &scope_iter))
+@@ -114,6 +119,7 @@ void register_machine(pid_t pid, const char *dest, const char *machine_name) {
+ 
+ 	if (!dbus_message_iter_close_container(&args, &scope_iter))
+ 		fail_printf("OOM");
++#endif /* USE_DBUS_CREATE_CONTAINER */
+ 
+ 	rep = dbus_connection_send_with_reply_and_block(conn, req, -1, &err);
+ 	if (dbus_error_is_set(&err))
+-- 
+2.11.0
+

--- a/meta-cube/recipes-containers/pflask/pflask_git.bb
+++ b/meta-cube/recipes-containers/pflask/pflask_git.bb
@@ -20,6 +20,7 @@ SRC_URI = "git://github.com/ghedo/pflask.git; \
            file://0001-pflask-support-move-wireless-netwrok-to-another-netn.patch \
            file://0001-pflask-add-hook-support.patch \
 	   file://0001-pflask-attach-Terminate-attach-when-the-parent-pflas.patch \
+	   file://0001-machined-interface-Use-RegisterMachine-instead-of-Cr.patch \
 	"
 
 SRCREV="38a7de2d6353d62ce325a5b1f0075adf76fe982c"

--- a/meta-cube/recipes-support/container-shutdown-notifier/files/container-shutdown-notifier
+++ b/meta-cube/recipes-support/container-shutdown-notifier/files/container-shutdown-notifier
@@ -3,12 +3,14 @@
 target_state=$( systemctl list-units --type=target )
 echo ${target_state} | grep -qi reboot
 if [ $? == 0 ]; then
-	command="reboot"
+	command="kill -INT 1"
 else
 	echo ${target_state} | grep -qi poweroff
 	if [ $? == 0 ]; then
-		command="poweroff"
+		command="kill -RTMIN+4 1"
 	fi
 fi
 
-timeout 5s bash -c "cube-cmd ${command}"
+# Only execute a shutdown if a shutdown is not already pending
+# else systemd will hang
+timeout 5s bash -c "cube-cmd systemctl list-jobs shutdown.target|grep -q shutdown.target||cube-cmd $command"

--- a/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
+++ b/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
@@ -10,6 +10,7 @@ SRC_URI = "file://essential-autostart \
            file://essential-autostart.service \
            file://reload-dom0-snapshot \
            file://reload-dom0-snapshot.service \
+           file://daemonize-sigusr1-wait.c \
 "
 
 SRC_FILES_LIST = "essential-autostart \
@@ -33,9 +34,13 @@ if type systemctl >/dev/null 2>/dev/null; then
 fi
 }
 
+do_compile() {
+	${CC} ${CFLAGS} ${LDFLAGS} -Wall ${WORKDIR}/daemonize-sigusr1-wait.c -o ${B}/daemonize-sigusr1-wait
+}
 
 do_install() {
     install -d ${D}/${sbindir}
+    install -m 0755 ${B}/daemonize-sigusr1-wait ${D}/${sbindir}
     for i in ${SRC_FILES_LIST}; do
         install -m 0755 ${WORKDIR}/${i} ${D}/${sbindir}
     done

--- a/meta-cube/recipes-support/essential-init/files/daemonize-sigusr1-wait.c
+++ b/meta-cube/recipes-support/essential-init/files/daemonize-sigusr1-wait.c
@@ -1,0 +1,85 @@
+/*
+ * daemonize-sigusr1-wait.c  Daemonize child after receiving sigusr1
+ *
+ * Copyright (c) 2017 Wind River Systems, Inc. - Jason Wessel
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#define _GNU_SOURCE
+#include <signal.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+
+static void daemonize(void)
+{
+	int ret = fork();
+	if (ret == 0) {
+		exit(0);
+	}
+}
+
+static void sig_handler(int signo)
+{
+	if (signo == SIGUSR1) {
+		daemonize();
+	}
+
+	return;
+}
+
+int main( int argc, char *argv[])
+{
+	int ret;
+	int status;
+	char *env_str;
+
+	if( signal( SIGUSR1, sig_handler) == SIG_ERR  )	{
+		perror("ERROR: Could not create handler SIGUSR1");
+		exit(-1);
+	}
+
+	/* Run child process */
+	if (argc < 2) {
+		printf("Usage: %s <child command>\n", argv[0]);
+		exit(-1);
+	}
+
+	if (!asprintf(&env_str, "%i", getpid())) {
+		perror("Alloc failed");
+		exit(-1);
+	}
+
+	setenv("SIGUSR1_PARENT_PID", env_str, 1);
+
+	argv += 1;
+	ret = fork();
+
+	if (ret == 0) {
+		/* Child */
+		execvp(argv[0], argv);
+		exit(-1);
+	}
+	if (ret < 0) {
+		printf("Error fork failed\n");
+		exit(-1);
+	}
+
+	wait(&status);
+	return(status);
+}

--- a/meta-cube/recipes-support/essential-init/files/essential-autostart
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+if [ "$1" = "stop" ] ; then
+    pid=`/bin/machinectl show dom0 -p Leader --value`
+    if [ ! -n "$pid" ] ; then
+	exit 0
+    fi
+
+    # Graceful shutdown required if root name space is shutting down
+    if systemctl list-jobs shutdown.target | grep -q shutdown.target ; then
+	kill -INT $pid
+    else
+	/bin/machinectl kill -s KILL dom0
+    fi
+
+    # Wait for signal to be processed by using tail against process pid
+    # which continues immediately when the pid is already gone
+    tail --pid=$pid -f /dev/null
+    exit 0
+fi
+
 container_dir="/opt/container"
 
 # if single_launch is set, then we don't use dtach, but instead let the

--- a/meta-cube/recipes-support/essential-init/files/essential-autostart.service
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Essential Autoboot Code
-After=syslog.target network.target
+After=syslog.target network.target machines.target getty.target
 After=dbus.service overc-conftools.service systemd-machined.service
 
 [Service]
 Type=forking
 RemainAfterExit=no
 ExecStart=-/usr/sbin/essential-autostart
-# Container dom0 ignores SIGTERM
-ExecStop=-/bin/machinectl kill -s KILL dom0
+ExecStop=-/usr/sbin/essential-autostart stop
 
 [Install]
 WantedBy=basic.target

--- a/meta-cube/recipes-support/overc-utils/source/cube-cfg
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cfg
@@ -911,7 +911,7 @@ mgr=\$(cat /opt/container/${container_name}/cube.container.mgr)
 if [ "\${args}" = "foreground" ] ; then
      \${mgr} run --bundle /opt/container/${container_name} ${container_name}
 else
-     \${mgr} create --bundle /opt/container/${container_name} \${runc_console} ${container_name}
+     /usr/sbin/daemonize-sigusr1-wait \${mgr} create --bundle /opt/container/${container_name} \${runc_console} ${container_name}
     if [ "\${console_mgr}" = "screen-tty" ] || [ "\${args}" = "debug" ]; then
 	/usr/bin/screen -ls console > /dev/null && /usr/bin/screen -S console -x -X \
 	  screen -t ${container_name} /var/lib/cube/${container_name}/pty-console


### PR DESCRIPTION
There is only one new patch here, but it stacks on top of the prior changes, which are not yet merged and why they appear here.

The new patch also needs the corresponding runc-docker change in meta-virtualization, but it will work in the existing mode of operation if the meta-virtualization change is not in the tree.  It just needs the meta-virtualization change in order to fully execute the runc stop hooks.