### PR TITLE
overc-system-agent: fix a wrong syntax in *_get_containers functions

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/container.py
@@ -159,7 +159,7 @@ class Container(object):
         return subprocess.check_output(cmd, shell=True).decode("utf-8").strip("\n")
 
     def get_container(self, template):
-        cmd = "cube-ctl list | tail -2 | awk '{ print $1 }'"
+        cmd = "cube-ctl list | sed -n '3,$p' | awk '{ print $1 }'"
         return subprocess.check_output(cmd, shell=True).decode("utf-8").strip("\n").split()
 
     def is_active(self, cn, template):

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/bash-completion/overc-bash-completion
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/bash-completion/overc-bash-completion
@@ -10,9 +10,9 @@ _overc_get_containers()
 {
     local exclude_dom0=$1
     if [ -n "$exclude_dom0" ]; then
-        echo $(/usr/sbin/cube-ctl list | tail -2 | awk '{ if ($1 != "dom0") print $1 }')
+        echo $(/usr/sbin/cube-ctl list | sed -n '3,$p' | awk '{ if ($1 != "dom0") print $1 }')
     else
-        echo $(/usr/sbin/cube-ctl list | tail -2 | awk '{ print $1 }')
+        echo $(/usr/sbin/cube-ctl list | sed -n '3,$p' | awk '{ print $1 }')
     fi
 }
 


### PR DESCRIPTION
I made a mistake in *_get_containers functions, I intended to skip the
first two lines from the 'cube-ctl list' output, but I actually let it
get the last two lines.

Fix it by replacing tail command by a sed command.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>