### PR TITLE
overc-system-agent: overc: add self.retval initialization

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/overc.py
@@ -61,6 +61,7 @@ class Overc(object):
         DIST = "Pulsar overc"
         succeeded = []
         for cn in containers:
+            self.retval = 0
             if self.container.is_active(cn, template):
                 for dist in DIST.split():
                     if dist in self.container.get_issue(cn, template).split():


### PR DESCRIPTION
This fixes a following issues:
| Traceback (most recent call last):
|  File "/opt/overc-system-agent/overc", line 184, in <module>
|    sys.exit(args.func())
|  File "/opt/overc-system-agent/Overc/overc.py", line 78, in _system_upgrade
|    if self.retval is not 0:
| AttributeError: 'Overc' object has no attribute 'retval'

Signed-off-by: Ming Liu <liu.ming50@gmail.com>