### PR TITLE
builder-base: mask bind.service from running by default

### DIFF
--- a/meta-cube/classes/builder-base.bbclass
+++ b/meta-cube/classes/builder-base.bbclass
@@ -6,12 +6,18 @@ EXTRA_USERS_PARAMS ?= "usermod -p '\$6\$itWJK/a95NGi5AVs\$0zlkWdhpXg5CWtEC0YxIH8
 
 ROOTFS_POSTPROCESS_COMMAND += "builder_configure_host ; "
 ROOTFS_POSTPROCESS_COMMAND += "systemd_autostart_fixups ; "
+ROOTFS_POSTPROCESS_COMMAND += "systemd_mask_tasks ; "
 
 builder_configure_host() {
 #    bbnote "builder: configuring host"
 
     echo "${TARGETNAME}" > ${IMAGE_ROOTFS}/etc/hostname
 
+}
+
+systemd_mask_tasks() {
+    # Turn off named
+    ln -sf /dev/null "${IMAGE_ROOTFS}/etc/systemd/system/named.service"
 }
 
 systemd_autostart_fixups() {


### PR DESCRIPTION
A number of binaries and libraries depend on the resolver libraries
provided by the bind package, but the bind service should not be
started by default as it causes conflicts with dnsmasq.  Having the
bind.service enabled and dnsmasq effectively creates a race condition
for one of the two services to get port 53.

This can be enabled later at run time or with start up changes easily.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>