### PR TITLE
bind: Turn bind off by default when installed

### DIFF
--- a/meta-cube/recipes-connectivity/bind/bind_%.bbappend
+++ b/meta-cube/recipes-connectivity/bind/bind_%.bbappend
@@ -1,0 +1,1 @@
+SYSTEMD_AUTO_ENABLE_${PN} = "disable"


### PR DESCRIPTION
The bind service conflicts with dnsmasq for port 53 and creates a race
condition when both are active.  If needed, bind can be enabled at
runtime or with symlink rules on a per image recipe basis.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>