### PR TITLE
overc-utils: cube-ctl: add tracking logic

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1234,6 +1234,10 @@ IFS=$OLDIFS
 	    echo "[INFO] Performing lxc configuration ..."
 	    generate_lxc_config ${container_name} ${out_dir}
 	fi
+
+	if [ -n "${track_containers}" ]; then
+	    ${SBINDIR}/overc-ctl track ${container_name} -o ${out_dir}
+	fi
 	;;
     rename|mv)
 	orig_name=${cmd_options_non_dashed[1]}


### PR DESCRIPTION
When '--track' option is being passed to cube-ctl, it needs track all
kind of containers but not only cube/docker containers.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>