### PR TITLE
cube-install: initial version

### DIFF
--- a/meta-cube/recipes-core/images/cube-install_1.0.bb
+++ b/meta-cube/recipes-core/images/cube-install_1.0.bb
@@ -1,0 +1,93 @@
+SUMMARY = "An image which can be used to run the cube installer scripts."
+DESCRIPTION = "Small image which can be used natively or as a cube to\
+               run the cube installer. Contains the tools required by\
+               the installer scripts."
+HOMEPAGE = "http://www.windriver.com"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+PACKAGE_EXCLUDE = "busybox*"
+
+# password-less login
+IMAGE_FEATURES += "debug-tweaks"
+
+IMAGE_LINGUAS = ""
+
+IMAGE_FSTYPES ?= "tar.bz2 hddimg"
+
+# Be sure to do this after setting IMAGE_FSTYPES to ensure proper 'live'
+# handling. See note in documentation for IMAGE_FSTYPES.
+inherit core-image
+
+export IMAGE_BASENAME = "cube-install"
+
+TARGETNAME ?= "cube-install"
+
+# Distro can override the following VIRTUAL-RUNTIME providers:
+VIRTUAL-RUNTIME_dev_manager ?= "udev"
+VIRTUAL-RUNTIME_login_manager ?= "shadow"
+VIRTUAL-RUNTIME_init_manager ?= "systemd"
+VIRTUAL-RUNTIME_initscripts ?= ""
+VIRTUAL-RUNTIME_keymaps ?= "keymaps"
+
+CUBE_INSTALL_EXTRA_INSTALL ?= "kernel-modules"
+
+# Required package
+PACKAGE_INSTALL = " \
+    bash \
+    base-files \
+    base-passwd \
+    ${@bb.utils.contains("MACHINE_FEATURES", "efi", "grub-efi efibootmgr", "grub", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "keyboard", "${VIRTUAL-RUNTIME_keymaps}", "", d)} \
+    netbase \
+    ${VIRTUAL-RUNTIME_login_manager} \
+    ${VIRTUAL-RUNTIME_init_manager} \
+    ${VIRTUAL-RUNTIME_dev_manager} \
+    ${VIRTUAL-RUNTIME_update-alternatives} \
+"
+
+# More essential packages
+PACKAGE_INSTALL += " \
+    shadow \
+    "
+
+PACKAGE_INSTALL += " \
+    ${CUBE_INSTALL_EXTRA_INSTALL} \
+    nfs-utils-client \
+    sed \
+    vim \
+    dhcp-client \
+    grep \
+    findutils \
+    iproute2 \
+    gawk \
+    iputils \
+    dropbear \
+    "
+
+# Required by the overc-installer scripts
+PACKAGE_INSTALL += " \
+    dosfstools \
+    util-linux \
+    file \
+    which \
+    jq \
+    e2fsprogs \
+    perl \
+    tar \
+    coreutils \
+    bzip2 \
+    python \
+    btrfs-tools \
+    "
+
+# Required by cubeit
+PACKAGE_INSTALL += " \
+    dialog \
+    parted \
+    procps \
+    "
+
+USE_DEVFS = "0"


### PR DESCRIPTION
Up to now we have used cube-essential as the rootfs in an OverC
installer image (live+payload). This worked well since cube-essential
was designed to run as a system rootfs and it avoided us having to
maintain another image type. Since we have moved to slim
cube-essential, however, it no longer contains all the applications
required to run the installer. We therefor add a new image type called
'cube-install'.

The intention of cube-install is initially to have a rootfs which can
be used in 'installer' images (live+payload). It contains everything
needed to boot plus the applications used by the installer
scripts. This is what is available in this commit.

In the future we should be able to add the ability to run cube-install
as a container. This will allow us for example to have OverC run from
a USB stick, created using the 'image' install, and then perform an
install to the system HDD by doing a 'c3 add cube-install', and
running the installer from cube-install. By removing the installation
binding from cube-essential and instead having a dedicated
cube-install we open the door to these possibilities, without
compromising cube-essential.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>