### PR TITLE
Master oci fixups

### DIFF
--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -19,8 +19,9 @@ PACKAGE_EXCLUDE_COMPLEMENTARY = "ruby|ruby-shadow|puppet|hiera|facter"
 
 CUBE_DESKTOP_EXTRA_INSTALL ?= ""
 
+RDEPENDS_packagegroup-dom0_remove = "linux-firmware"
+
 IMAGE_INSTALL += "packagegroup-core-boot \
-                        packagegroup-dom0 \
                         packagegroup-util-linux \
                         packagegroup-core-ssh-openssh \
                         packagegroup-core-full-cmdline \

--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1012,9 +1012,9 @@ case "${cmd}" in
 	if [ -n "${subuid}" ]; then
 	    if [ -n "${we_are_a_container}" ]; then
 		privilege_param="-u ${subuid}"
-		cube-cmd cmd "touch /etc/subuid /etc/subgid"
-		cube-cmd cmd "usermod --add-subuids ${subuid}-$(( subuid+65536 )) root"
-		cube-cmd cmd "usermod --add-subgids ${subuid}-$(( subuid+65536 )) root"
+		cube-cmd "touch /etc/subuid /etc/subgid"
+		cube-cmd "usermod --add-subuids ${subuid}-$(( subuid+65536 )) root"
+		cube-cmd "usermod --add-subgids ${subuid}-$(( subuid+65536 )) root"
 	    else
 		touch /etc/subuid /etc/subgid
 		usermod --add-subuids ${subuid}-$(( subuid+65536 )) root
@@ -1140,7 +1140,7 @@ IFS=$OLDIFS
 
 	if [ -n "${subuid}" ]; then
 	    if [ -n "${we_are_a_container}" ]; then
-		cube-cmd cmd "chown -R ${subuid}:${subuid} ${out_dir}/${container_name}/rootfs"
+		cube-cmd "chown -R ${subuid}:${subuid} ${out_dir}/${container_name}/rootfs"
 	    else
 		chown -R ${subuid}:${subuid} ${out_dir}/${container_name}/rootfs
 	    fi
@@ -2133,7 +2133,7 @@ EOF
 		echo "running: cube-cmd ${cmd_to_exec[@]}"
 	    fi
 
-	    cube-cmd cmd ${cmd_to_exec[@]}
+	    cube-cmd ${cmd_to_exec[@]}
 	else
 	    mgr=$(cube-cfg -o /opt/container/${container_name}/ get cube.container.mgr)
 	    echo ${mgr} | grep -q runc

--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -690,7 +690,7 @@ service_disable()
     fi
 
     if [ -z "${slinks}" ]; then
-        debugmsg ${DEBUG_INFO} ${debug_msg}
+        debug_msg ${DEBUG_INFO} ${debug_msg}
         return 1
     fi
 


### PR DESCRIPTION
2 bug fixes for minor issues in cube-ctl.

1 update to start to shrink cube-desktop since it started to be too big to fit in our typical 7GB test image, and since it has no reason to contain 300MB+ of kernel firmware.