### PR TITLE
New c3-*-containers

### DIFF
--- a/docs/README.c3_app_container
+++ b/docs/README.c3_app_container
@@ -1,0 +1,53 @@
+c3-app-container
+-------------------------
+
+The meta-cube layer comes with a single 'flexible' image called
+'c3-app-container'. This image allows you to build a single
+application container where you select the application which the image
+will contain. Application selection is made via local.conf, by setting
+'C3_APP_CONTAINER_APP' to the name of the application.
+
+
+Building
+-------------------------
+
+The image is built using the normal bitbake commands:
+%> bitbake c3-app-container
+
+The output will be found in the tmp/deploy/images/* directory
+alongside the other images.
+
+
+Usage
+-------------------------
+
+You can use the c3-app-container as an artifact to the cubeit
+installer but more likely you will install the image on a running
+system. This would be done by copying the image tarball to the target
+running OverC and then running the following commands on dom0 or in a
+container with bindings to dom0:
+
+# c3 add -n app-container c3-app-container-genericx86-64.tar.bz2
+# c3 cfg -o /opt/container/app-container set app:/usr/bin/<your_app> [options]
+# c3 start [options] app-container
+
+
+Image size
+-------------------------
+
+The image size will depend on your selected application. As with any
+image, bitbake will include any dependencies in the image and as such
+the size can easily grow. A small application with no/few dependencies
+will result in a image of only a few MB.
+
+
+Creating more than one app container
+-------------------------
+
+The use of the 'c3-app-container' and 'C3_APP_CONTAINER_APP' is
+restricted to one application. However, you may use the
+c3-app-container.inc in your own image recipe in a similar way
+c3-app-container_*.bb does. This will allow you to write your own
+application container images in only a few lines, and, any
+improvements made to the c3-app-container.inc will immediately be
+available in your image.

--- a/docs/README.c3_systemd_container
+++ b/docs/README.c3_systemd_container
@@ -1,0 +1,85 @@
+c3-app-container
+-------------------------
+
+The meta-cube layer comes with a single 'flexible' systemd system
+image called 'c3-systemd-container'. This image allows you to build a
+single systemd system container where you select the application(s)
+which the image will contain. Application selection(s) is made via
+local.conf, by setting 'C3_SYSTEMD_CONTAINER_APPS' to the name of the
+application.
+
+
+Configuration
+-------------------------
+
+How c3-systemd-container is configured is controlled by 3 variables
+which are intended to be defined in local.conf:
+
+* C3_SYSTEMD_CONTAINER_APPS - required - a space separated list of
+  application(s) to included in the image. Usually this is one
+  application such as 'apached2'.
+
+* C3_SYSTEMD_CONTAINER_ENABLE_SERVICES - optional - a space separated
+  list of systemd services to enable. This is performed during
+  do_rootfs(). This may not always be needed but some recipes default
+  disabled (via 'SYSTEMD_AUTO_ENABLE_${PN} = "disable"') such as
+  apache2. You can use other methods to overwrite this default, this
+  variable just makes it easy.
+
+* C3_SYSTEMD_CONTAINER_DISABLE_SERVICES - optional - additional
+  systemd services to disable, c3-systemd-container.inc defines a
+  minimal set of services that shouldn't be run in a container. Like
+  C3_SYSTEMD_CONTAINER_ENABLE_SERVICES this is performed during
+  do_rootfs(). If you want to overwrite the minimal list you can
+  assign 'SERVICES_TO_DISABLE_pn-c3-systemd-container' in local.conf.
+
+So for example you might define the following in your local.conf to
+build a systemd system container for apache2:
+
+C3_SYSTEMD_CONTAINER_APPS = "apache2"
+C3_SYSTEMD_CONTAINER_ENABLE_SERVICES = "apache2.service"
+
+
+Building
+-------------------------
+
+The image is built using the normal bitbake commands:
+%> bitbake c3-systemd-container
+
+The output will be found in the tmp/deploy/images/* directory
+alongside the other images.
+
+
+Usage
+-------------------------
+
+You can use the c3-systemd-container as an artifact to the cubeit
+installer but more likely you will install the image on a running
+system. This would be done by copying the image tarball to the target
+running OverC and then running the following commands on dom0 or in a
+container with bindings to dom0:
+
+# c3 add -n systemd-container c3-systemd-container-genericx86-64.tar.bz2
+# c3 start [options] systemd-container
+
+
+Image size
+-------------------------
+
+The image size will depend on your selected application. As with any
+image, bitbake will include any dependencies in the image (including
+those of systemd itself) and as such the size can easily grow. A small
+application with no/few dependencies will result in a image of about
+15 MB.
+
+
+Creating more than one app container
+-------------------------
+
+The use of the 'c3-systemd-container' and 'C3_SYSTEMD_CONTAINER_*' is
+restricted to one image/configuration. However, you may use the
+c3-systemd-container.inc in your own image recipe in a similar same
+way as c3-systemd-container_*.bb does. This will allow you to write
+your own systemd system container images in only a few lines, and, any
+improvements made to the c3-systemd-container.inc will immediately be
+available in your image.

--- a/meta-cube/recipes-core/images/c3-app-container.inc
+++ b/meta-cube/recipes-core/images/c3-app-container.inc
@@ -1,0 +1,18 @@
+SUMMARY ?= "Sample application container"
+DESCRIPTION ?= "A small application container which will run \
+                the application defined in IMAGE_INSTALL."
+HOMEPAGE ?= "http://www.windriver.com"
+
+LICENSE ?= "MIT"
+LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
+
+TARGETNAME ?= "c3-app-container"
+
+IMAGE_INSTALL += ""
+
+IMAGE_FEATURES = ""
+
+inherit image

--- a/meta-cube/recipes-core/images/c3-app-container_1.0.bb
+++ b/meta-cube/recipes-core/images/c3-app-container_1.0.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Application container for ${C3_APP_CONTAINER_APP}"
+DESCRIPTION = "A small application container which will run \
+                ${C3_APP_CONTAINER_APP}."
+HOMEPAGE = "http://www.windriver.com"
+
+require c3-app-container.inc
+
+IMAGE_INSTALL += "${C3_APP_CONTAINER_APP}"

--- a/meta-cube/recipes-core/images/c3-systemd-container.inc
+++ b/meta-cube/recipes-core/images/c3-systemd-container.inc
@@ -1,0 +1,59 @@
+SUMMARY ?= "Sample systemd system container"
+DESCRIPTION ?= "A small systemd system container which will run \
+                the application defined in IMAGE_INSTALL."
+HOMEPAGE ?= "http://www.windriver.com"
+
+LICENSE ?= "MIT"
+LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+IMAGE_FSTYPES ?= "tar.bz2"
+IMAGE_FSTYPES_remove = "live"
+
+TARGETNAME ?= "c3-systemd-container"
+
+IMAGE_INSTALL_append += "systemd"
+
+IMAGE_FEATURES = ""
+
+NO_RECOMMENDATIONS = "1"
+
+SERVICES_TO_DISABLE ?= " \
+    systemd-udevd.service \
+    systemd-udevd-control.socket \
+    systemd-udevd-kernel.socket \
+    proc-sys-fs-binfmt_misc.automount \
+    sys-fs-fuse-connections.mount \
+    sys-kernel-debug.mount \
+    systemd-hwdb-update.service \
+    serial-getty@ttyS0.service \
+    dev-ttyS0.device \
+"
+
+SERVICES_TO_ENABLE ?= ""
+
+disable_systemd_services () {
+	SERVICES_TO_DISABLE="${SERVICES_TO_DISABLE}"
+	if [ -n "$SERVICES_TO_DISABLE" ]; then
+		echo "Disabling systemd services:"
+		for service in $SERVICES_TO_DISABLE; do
+			echo "    $service"
+			systemctl --root="${IMAGE_ROOTFS}" mask $service > /dev/null >1
+		done
+	fi
+}
+
+enable_systemd_services () {
+	SERVICES_TO_ENABLE="${SERVICES_TO_ENABLE}"
+	if [ -n "$SERVICES_TO_ENABLE" ]; then
+		echo "Enabling additional systemd services:"
+		for service in $SERVICES_TO_ENABLE; do
+			echo "    $service"
+			systemctl --root="${IMAGE_ROOTFS}" enable $service > /dev/null >1
+		done
+	fi
+}
+
+
+ROOTFS_POSTPROCESS_COMMAND += "disable_systemd_services; enable_systemd_services;"
+
+inherit image

--- a/meta-cube/recipes-core/images/c3-systemd-container_1.0.bb
+++ b/meta-cube/recipes-core/images/c3-systemd-container_1.0.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Systemd system container for ${C3_SYSTEMD_CONTAINER_APP}"
+DESCRIPTION = "A small systemd system container which will run \
+                ${C3_SYSTEMD_CONTAINER_APP}."
+HOMEPAGE = "http://www.windriver.com"
+
+
+# Use local.conf to specify the application(s) to install
+IMAGE_INSTALL = "${C3_SYSTEMD_CONTAINER_APPS}"
+
+# Use local.conf to specify additional systemd services to disable. To overwrite
+# the default list use SERVICES_TO_DISABLE_pn-c3-systemd-container in local.conf
+SERVICES_TO_DISABLE_append += "${C3_SYSTEMD_CONTAINER_DISABLE_SERVICES}"
+
+# Use local.conf to enable systemd services
+SERVICES_TO_ENABLE += "${C3_SYSTEMD_CONTAINER_ENABLE_SERVICES}"
+
+require c3-systemd-container.inc


### PR DESCRIPTION
We want to accomplish several goals with these changes:
* Provide the user with an easy way to build an app or (systemd) system images. This is accomplished with the 2 new images recipes which allow for *one* of each image type to be built, just be editing local.conf.

* Provide the user with an easy way to define their own app or (systemd) system images. This is accomplished by defining an initial set of .inc files which the user can include in their own image recipes

* Provide a way for image files to benefit from future fixups to improve things like size. This is again provided by the .inc files. If people define their container images by including these .inc files, any future changes will be inherited.

* Provide documentation so these things don't just sit unused and not understood. Done.