### PR TITLE
Fix build failures on latest Yocto HEAD

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
+++ b/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
@@ -17,8 +17,6 @@ RDEPENDS_${PN}-bash-completion = "bash-completion"
 
 RDEPENDS_${PN} = "\
 	btrfs-tools \
-	python3-argparse \
-	python3-subprocess \
 	python3-flask \
 	python3-itsdangerous \
 	python3-jinja2 \


### PR DESCRIPTION
A recent (Jan 20th) update to poky pulled in a major overhaul of python3 packaging from openembedded-core. This change moved several formerly independent python3 packages in to the core python3 package. As such we can no longer RDEPEND on them and can safely drop our explicit RDEPENDS.