### PR TITLE
cube-ctl netprime fixups

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -2060,7 +2060,10 @@ EOF
 		#       needs to vary and we can't stop the container
 		cd ${out_dir}/${network_prime_old}
 		${SBINDIR}/cube-cfg attribute -netprime
-		${SBINDIR}/cube-cfg set cube.network.type:dynamic
+		# The vrf and netprime need to be static, so leave static if we are the vrf
+		if [ "${network_prime_old}" != "$(container_by_attribute vrf)" ]; then
+		    ${SBINDIR}/cube-cfg set cube.network.type:dynamic
+		fi
 		${SBINDIR}/cube-cfg set -cube.network.ip:192.168.42.1/24
 
 		devs=$(${SBINDIR}/cube-cfg -o ${out_dir}/${network_prime_old} device network)

--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -2073,10 +2073,14 @@ EOF
 		done
 
 		# remove the old hook and etcd port forward
-		${SBINDIR}/cube-cfg hook-script -poststart:/usr/libexec/cube/hooks.d/cube-netconfig netprime \$\(cat\)
+		type=$(get_container_type ${network_prime_old})
+		if [ "${type}" == "oci" ]; then
+		    ${SBINDIR}/cube-cfg hook-script -poststart:/usr/libexec/cube/hooks.d/cube-netconfig netprime \$\(cat\)
+		else
+		    ${SBINDIR}/cube-cfg hook-script -poststart:/usr/libexec/cube/hooks.d/cube-netconfig netprime
+		fi
 		${SBINDIR}/cube-cfg link -${network_prime_old}:2379 dom0:2379
 
-		type=$(get_container_type ${network_prime_old})
 		${SBINDIR}/cube-cfg gen ${network_prime_old}:$type
 	    )
 	fi


### PR DESCRIPTION
Two small fixes to allow the functionality to work for moving the netprime around, specifically when things start with dom0 being the netprime.