### PR TITLE
cube-ctl: don't match on substrings

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1710,7 +1710,7 @@ EOF
 
 	mgr=$(cube-cfg -n ${container_name} get cube.container.mgr:)
 	if [ -n "${container_is_a_oci}" ]; then
-	    echo ${open_containers_running} | grep -q ${container_name}
+	    echo ${open_containers_running} | tr ' ' '\n' | grep -qw ${container_name}
 	    if [ $? -ne 0 ]; then
 		echo "[INFO] deleting container ${container_name}"
 		cube-cmd ${mgr} delete ${container_name} 2> /dev/null
@@ -2116,7 +2116,7 @@ EOF
 	mgr=$(cube-cfg -n ${container_name} get cube.container.mgr:)
 	if [ -n "${container_is_a_oci}" ]; then
 	    build_container_lists
-	    echo ${open_containers_running} | grep -q ${container_name}
+	    echo ${open_containers_running} | tr ' ' '\n' | grep -qw ${container_name}
 	    if [ $? -eq 0 ]; then
 		echo "[INFO]: stopping container ${container_name}"
 		cube-cmd ${mgr} kill ${container_name} KILL


### PR DESCRIPTION
Attempting to delete a container named 'deb' while a container named
'debian' is running will result in

  [INFO] container deb is running, it must be stopped before deleting

When comparing the container name to the list of running containers we
are matching when the container name is a substring of another
container in the list. We could make use of bash string matching to
avoid this but so far we have avoid using bash only constructs. We
could also grep on "($| )${container_name}( |$)" but the method used
here I believe reads the best.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>