### PR TITLE
c3-completions: docs: update to reflect recent changes

### DIFF
--- a/README.runtime
+++ b/README.runtime
@@ -165,12 +165,14 @@ cube-ctl:
 
 commands (and options):
 
- cube-ctl start [--peer] [--nested] <name>
+ cube-ctl start [-f] [-i] [-a] [auto=<name>] [<name>]
 
     start (launch) a container (dom0 only):
 
-       --peer (default)
-       --nested
+       -f: Start container in foreground on current tty
+       -i: Start interactive container console in foreground on current tty.
+       -a: attach container console just prior to start on current tty.
+       --auto=<name>: start containers with autostart set to <name>
        <name>: name of the container to be launched
 
  cube-ctl stop <name>
@@ -193,10 +195,10 @@ commands (and options):
 
     display detailed information about container <name>
 
- cube-ctl restart <name> # (dom0 only):
+ cube-ctl rename <name> <new_name> # (dom0 only):
+ cube-ctl mv <name> <new_name> # (dom0 only):
 
-    restart container <name>. A graceful shutdown and relaunch will be
-    performed.
+    rename container <name> to <new_name>.
 
 Examples:
 

--- a/meta-cube/recipes-support/overc-utils/source/c3-completions
+++ b/meta-cube/recipes-support/overc-utils/source/c3-completions
@@ -135,14 +135,16 @@ _c3_ctl_module()
         COMPREPLY=( $(compgen -W '$(_c3_containers)' -S ':' -- $cur) )
         return 0
         ;;
-    'info'|'show'|'prep'|'netprime'|'stop')
+    'info'|'show'|'prep'|'netprime'|'stop'|'rename'|'mv')
         COMPREPLY=( $(compgen -W '$(_c3_containers)' -- $cur) )
         return 0
         ;;
     esac
 
     # Handle the multipart commands
-    if _c3_contains COMP_WORDS "del"; then
+    if _c3_contains COMP_WORDS "del" ||
+       _c3_contains COMP_WORDS "delete" ||
+       _c3_contains COMP_WORDS "remove"; then
         if _c3_contains COMP_WORDS "-F"; then
             COMPREPLY=( $(compgen -W '$(_c3_containers)' -- $cur) )
         else
@@ -151,9 +153,9 @@ _c3_ctl_module()
         return 0
     elif _c3_contains COMP_WORDS "start"; then
         if [[ "$COMP_LINE" =~ "--auto" ]]; then
-            COMPREPLY=( $(compgen -W '--peer --nested' -- $cur) )
+            COMPREPLY=( $(compgen -W '-f -i -a' -- $cur) )
         else
-            COMPREPLY=( $(compgen -W '--peer --nested --auto= $(_c3_containers)' -- $cur) )
+            COMPREPLY=( $(compgen -W '-f -i -a --auto= $(_c3_containers)' -- $cur) )
         fi
         return 0
     elif _c3_contains COMP_WORDS "stack"; then
@@ -198,8 +200,8 @@ _c3_ctl_module()
         ;;
     esac
 
-    COMPREPLY=( $(compgen -W 'start stop netprime stack store prep \
-                              add del status list -i info show \
+    COMPREPLY=( $(compgen -W 'start stop netprime stack store prep add del \
+                              delete remove rename mv status list -i info show \
                               ' -- $cur) )
 
     return 0
@@ -239,7 +241,8 @@ _c3_module()
 
     # Include the cube-ctl "level 0" matches since we default to cube-ctl cmds
     COMPREPLY=( $(compgen -W 'ctl cmd cfg start stop netprime stack store prep \
-                              add del status list -i info show' -- $cur) )
+                              add del delete remove rename mv status list -i \
+			      info show' -- $cur) )
 
     return
 } &&


### PR DESCRIPTION
There have been some changes to c3-ctl which were yet to be reflected
in the bash completions or the documentation. Follow through with
these changes to keep things current.

* Add foreground, interactive and attach options to start
* Add rename/mv command
* Remove --peer and --nested options no longer available to start
* Remove restart command from documentation

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>