### PR TITLE
ostree: Uprev to fix compile problem against new libc headers

### DIFF
--- a/meta-cube/recipes-support/ostree/ostree_git.bb
+++ b/meta-cube/recipes-support/ostree/ostree_git.bb
@@ -9,9 +9,9 @@ SRC_URI = " \
     file://0001-autogen.sh-fall-back-to-no-gtkdocize-if-it-is-there-.patch \
 "
 
-SRCREV = "ae61321046ad7f4148a5884c8c6c8b2594ff840e"
+SRCREV = "81560cada648b247ccdc9ea6ad4846a7276056e0"
 
-PV = "2017.13+git${SRCPV}"
+PV = "2018.2+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 inherit autotools-brokensep pkgconfig systemd gobject-introspection


### PR DESCRIPTION
The new libc headers error as follows:

| Makefile:4659: recipe for target 'src/libostree/libostree_1_la-ostree-repo-checkout.lo' failed
| make[2]: *** [src/libostree/libostree_1_la-ostree-repo-checkout.lo] Error 1
| In file included from ./libglnx/glnx-missing.h:95:0,
|                  from ./libglnx/libglnx.h:28,
|                  from src/libostree/ostree-repo-traverse.c:24:
| ./libglnx/glnx-missing-syscall.h:142:23: error: static declaration of 'copy_file_range' follows non-static declaration
|  static inline ssize_t copy_file_range(int fd_in, loff_t *off_in,
|                        ^~~~~~~~~~~~~~~

This is fixed upstream in the latest release version of ostree.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>