### PR TITLE
cube-essential: Add in parted

### DIFF
--- a/meta-cube/recipes-core/images/cube-essential_0.3.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.3.bb
@@ -31,6 +31,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   jq \
                   ${CUBE_ESSENTIAL_EXTRA_INSTALL} \
                   ${OVERC_VMSEP_PACKAGES} \
+		  parted \
 		  kernel-image \
                  "
 


### PR DESCRIPTION
The cube-essential is used for the installer and requires parted to
exist both to query the partition table and manage teh partitions.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>