### PR TITLE
Fixes to package groups

### DIFF
--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -25,7 +25,6 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                         packagegroup-util-linux \
                         packagegroup-core-ssh-openssh \
                         packagegroup-core-full-cmdline \
-                        packagegroup-builder \
                         packagegroup-xfce \
                         packagegroup-container \
                         packagegroup-networkmanager \

--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -19,8 +19,6 @@ PACKAGE_EXCLUDE_COMPLEMENTARY = "ruby|ruby-shadow|puppet|hiera|facter"
 
 CUBE_DESKTOP_EXTRA_INSTALL ?= ""
 
-RDEPENDS_packagegroup-dom0_remove = "linux-firmware"
-
 IMAGE_INSTALL += "packagegroup-core-boot \
                         packagegroup-util-linux \
                         packagegroup-core-ssh-openssh \

--- a/meta-cube/recipes-core/images/cube-server_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-server_0.2.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   packagegroup-core-ssh-openssh \
                   packagegroup-core-full-cmdline \
                   packagegroup-util-linux \
-                  packagegroup-builder \
                   packagegroup-dom0 \
                   packagegroup-container \
                   ${CUBE_SERVER_EXTRA_INSTALL} \

--- a/meta-cube/recipes-core/images/cube-server_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-server_0.2.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   packagegroup-core-ssh-openssh \
                   packagegroup-core-full-cmdline \
                   packagegroup-util-linux \
-                  packagegroup-dom0 \
                   packagegroup-container \
                   ${CUBE_SERVER_EXTRA_INSTALL} \
                   "


### PR DESCRIPTION
Remove compilers by default, because you can use/install cube-builder when needed.

Remove pacakgegroup-dom0 completely from cube-desktop and cube-server.