### PR TITLE
cube-ctl: Optimize "c3 add" instantiation time

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1095,9 +1095,9 @@ case "${cmd}" in
 	    out_dir="${container_dir}/"
 	fi
 
-	# if [ -n "${track_containers}" ]; then
-	#     ${SBINDIR}/overc-ctl track ${container_name} -o ${out_dir}
-	# fi
+	if [ -n "${track_containers}" -a ! -e ${out_dir} ]; then
+	    ${SBINDIR}/overc-ctl subvol ${container_name} -o ${out_dir}
+	fi
 	mkdir -p "${out_dir}/${container_name}/rootfs"
 	case ${container_source} in
 	    *.tar*|*.tgz)
@@ -1154,7 +1154,7 @@ case "${cmd}" in
 			track_opt="--track"
 		fi
 		# recursive call!! This may mean we need an import tool front end, instead of doing this here
-		cube-ctl add ${track_opt}  -n ${container_name} ${out_dir}/${container_name}/oci-runtime
+		cube-ctl add ${track_opt}  -n ${container_name} move://${out_dir}/${container_name}/oci-runtime
 
 OLDIFS=$IFS
 IFS='
@@ -1186,6 +1186,24 @@ IFS=$OLDIFS
 		rm -rf ${out_dir}/${container_name}/oci-runtime
 
 		exit 0
+		;;
+	    move://*)
+		container_source=${container_source#move://}
+		if [ -d ${container_source} ]; then
+		    echo "[INFO] Adding ${container_source} to ${container_name}"
+
+		    # could be further refined to pick up a config.json and do an
+		    # oci maniplation, but for now, we just cp -ar
+		    if [ -d ${container_source}/rootfs ]; then
+			rm -rf ${out_dir}/${container_name}/rootfs
+			mv ${container_source}/rootfs ${out_dir}/${container_name}
+		    else
+			mv ${container_source}/* ${out_dir}/${container_name}/rootfs
+		    fi
+		else
+		    echo "[ERROR]: unknown container source"
+		    exit 1
+		fi
 		;;
 	    *)
 		if [ -d ${container_source} ]; then
@@ -1317,9 +1335,6 @@ IFS=$OLDIFS
 	    generate_lxc_config ${container_name} ${out_dir}
 	fi
 
-	if [ -n "${track_containers}" ]; then
-	    ${SBINDIR}/overc-ctl track ${container_name} -o ${out_dir}
-	fi
 	;;
     rename|mv)
 	orig_name=${cmd_options_non_dashed[1]}


### PR DESCRIPTION
This change is dependent on the change to overc-installer for the
subvol create support.

There are two separate optimizations:

1) In the case that tracking is enabled (which should be the default)
   - A btrfs subvol is created instead of copying and moving things
     around with snapshots later on.
   - This allows the erase operation to just be a simple delete volume
     instead of removing all the files with rm -rf

2) When using a container registry use a move operation instead of
   cp -a so there is no point where we need two copies of everything
   in the container's rootfs, just to turn around and delete one
   of the copies before completing the c3 add.

The speed improvement for a 250 MB container with 21,000 files was
going from 61 seconds to 26 seconds.  In each case 12 of seconds spent
are just for the download from the container registry.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>