### PR TITLE
cube-network: Fix regressions from patches that were dropped

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -177,13 +177,24 @@ if [ "${action}" = "up" ]; then
     #
     # Configure the container networking:
     #   1) loopback interface
-    #   2) dhcp address for the veth-br-int
+    #   2) dhcp address for the ${veth_name}
     #   3) default route configuration
     #
     nsenter -t ${pid} -n --preserve-credentials ip link set dev lo up
     nsenter -t ${pid} -n --preserve-credentials ip link set dev ${veth_name} up
+    if [ -f "cube.network.mac" ]; then
+       mac_address=$(cat cube.network.mac)
+    else
+        # Use a hashed MAC address based on the container name
+        mac_address=$(hashmac $(cat /etc/machine-id) ${cname})
+    fi
+    nsenter -t ${pid} -n --preserve-credentials ip link set dev ${veth_name} up address ${mac_address}
+
     if [ "${network}" == "dynamic" ]; then
-	command="dhclient -sf /usr/sbin/dhclient-script.container -e CONTAINER=${cname} --no-pid ${veth_name} >> /dev/null 2>&1"
+	command="dhclient -lf /opt/container/${cname}/rootfs/var/lib/dhcp/dhclient.leases -sf /usr/sbin/dhclient-script.container -e CONTAINER=${cname} --no-pid ${veth_name} >> /dev/null 2>&1"
+	if [ ! -d /opt/container/${cname}/rootfs/var/lib/dhcp ] ; then
+	    mkdir -p /opt/container/${cname}/rootfs/var/lib/dhcp
+	fi
 	eval nsenter -t ${pid} -n -- ${command}
 	if [ -e "/etc/resolv.conf.${cname}" ]; then
 	    mv /etc/resolv.conf.${cname} /opt/container/${cname}/rootfs/etc/resolv.conf
@@ -210,15 +221,6 @@ if [ "${action}" = "up" ]; then
 	    let count=${count}+1
 	done
     fi
-
-    if [ -f "cube.network.mac" ]; then
-	mac_address=$(cat cube.network.mac)
-    else
-	# cube's use the internal mac range: x6-xx-xx-xx-xx-xx
-	last_ip_range=$(echo $primary_ip | cut -f4 -d.)
-	mac_address=$(printf "06:00:00:00:00:%02x" ${last_ip_range})
-    fi
-    nsenter -t ${pid} -n --preserve-credentials ip link set dev ${veth_name} up address ${mac_address}
 
     gateway="192.168.42.1"
     if [ -f "cube.network.gateway" ]; then


### PR DESCRIPTION
commit ca060b46241251d6c5d97cdc571a116569b57d48 (overc-conf: drop
oci-network, since cube-network is now universal) accidentally dropped
two patches that were used in the oci-network.  The older patches
cleanly apply so long as the veth-br-int is changed to ${veth_name}.

The MAC address is changing after dhclient is running which causes a
problem where you lose IP connectivity after a while when the lease
renews.  It also poses a problem where you cannot get a lease in a
timely manner because the local lease db was being shared across
containers, so for the first container everything was fine, but each
additional container could incur a delay.

--- Restore commit ca060b46241251d6c5d97cdc571a116569b57d48 ---

oci-network: Use a private lease file for each container for dhclient

The dhclient state file cannot be shared if the interface name is the
same in a container.  It will cause the wrong IP address to be passed
for a renew request.

--- Restore commit feb6b8ef13fb6ebeb6e476defaa31d93cc3f4872 ---

oci-network: Move MAC assignment before dhclient and use a hash function

The MAC assignment needs to come before the dhclient request else the
network address changes later on when it renews the lease.

For speed and consistent operations the MAC address should be the same
across container restarts so we can use a hash function to generate
the mac address.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>