### PR TITLE
cube-ctl: Add a randomized uuid for any created container

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1165,6 +1165,12 @@ IFS='
 		    done
 		fi
 IFS=$OLDIFS
+		# Initialize container UUID if not already set
+		cube-cfg -n ${container_name} get cube.env |grep ^container_uuid=
+		if [ $? != 0 ] ; then
+		    uuid=`uuidgen | sed 's/-//g'`
+		    cube-cfg -n ${container_name} set cube.env:container_uuid=${uuid}
+		fi
 
 		if [ -n "${cwd}" ]; then
 		    cube-cfg -n ${container_name} set cube.dir:${cwd}
@@ -1306,6 +1312,13 @@ IFS=$OLDIFS
 		# update the container manager
 		graft_binaries_to_essential runc
 		${SBINDIR}/cube-cfg set cube.container.mgr:/var/lib/cube/essential/sbin/runc
+
+		# Initialize container UUID if not already set
+		${SBINDIR}/cube-cfg -n ${container_name} get cube.env |grep ^container_uuid=
+		if [ $? != 0 ] ; then
+		    uuid=`uuidgen | sed 's/-//g'`
+		    ${SBINDIR}/cube-cfg -n ${container_name} set cube.env:container_uuid=${uuid}
+		fi
 
 		${SBINDIR}/cube-cfg gen ${container_name}:oci
 


### PR DESCRIPTION
The latest version of systemd expects that a container will have the
variable container_uuid controlled by the container manager.  If an
end user does not set the container_uuid with c3 cfg set -n CONTAINER
cube.env:container_uuid the c3 add command will have done it for them.

Failure to set the container_uuid in a network prime container results
in programs like the Network Manager using a new client ID for each
reboot, which in turn causes you to get a new IP address on each
reboot.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>