### PR TITLE
cube-desktop: Turn off networkd configuration by default

### DIFF
--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -65,3 +65,5 @@ TARGETNAME ?= "cube-desktop"
 inherit core-image
 inherit builder-base
 
+# Override the cube configuration of networkd
+ROOTFS_POSTPROCESS_COMMAND_remove = "systemd_openvswitch_network;"


### PR DESCRIPTION
The NetworkManager is managing the network devices by default in the
cube-desktop.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>