### PR TITLE
conf: drop meta-yocto layer

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -7,7 +7,6 @@ BBFILES ?= ""
 
 BBLAYERS ?= " \
   $HOME/poky/meta \
-  $HOME/poky/meta-yocto \
   $HOME/poky/meta-yocto-bsp \
   $HOME/poky/meta-overc \
   $HOME/poky/meta-overc/meta-cube \


### PR DESCRIPTION
The meta-yocto layer has be dropped for Yocto since poky commit
145c245a56ff [meta-yocto: Drop meta-yocto directory] so we need to
drop the associated line from the bblayers.conf.sample file.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>