### PR TITLE
overc-utils: add missing RDEPENDS

### DIFF
--- a/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
@@ -70,4 +70,6 @@ FILES_${PN} += "/opt/${BPN} ${datadir}/bash-completion \
 
 FILES_overc-device-utils += "${sbindir}/cube-device ${sysconfdir}/udev ${sysconfdir}/cube-device"
 
-RDEPENDS_${PN} += "bash dtach nanomsg udev systemd-extra-utils jq overc-installer udocker"
+RDEPENDS_${PN} += "bash dtach nanomsg udev systemd-extra-utils jq overc-installer udocker \
+                   sed which grep \
+"


### PR DESCRIPTION
The scripts use several utilities which we need to ensure are included
in the image. These are indirectly included in dom0 but if we attempt
to place overc-utils in more minimal images where these are absent the
scripts will fail to run properly.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>