### PR TITLE
Remove packagegroup-builder from cube-desktop and cube-server

### DIFF
--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -27,7 +27,6 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                         packagegroup-util-linux \
                         packagegroup-core-ssh-openssh \
                         packagegroup-core-full-cmdline \
-                        packagegroup-builder \
                         packagegroup-xfce \
                         packagegroup-container \
                         packagegroup-networkmanager \

--- a/meta-cube/recipes-core/images/cube-desktop_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-desktop_0.2.bb
@@ -32,6 +32,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                         packagegroup-networkmanager \
                         packagegroup-audio \
                         ${OVERC_COMMON_TOOLS} \
+                        ${OVERC_COMMON_EXTENDED} \
                         ntp \
                         ntpdate \
                         ntp-utils \

--- a/meta-cube/recipes-core/images/cube-server_0.2.bb
+++ b/meta-cube/recipes-core/images/cube-server_0.2.bb
@@ -24,7 +24,6 @@ IMAGE_INSTALL += "packagegroup-core-boot \
                   packagegroup-core-ssh-openssh \
                   packagegroup-core-full-cmdline \
                   packagegroup-util-linux \
-                  packagegroup-builder \
                   packagegroup-dom0 \
                   packagegroup-container \
                   ${CUBE_SERVER_EXTRA_INSTALL} \


### PR DESCRIPTION
Also fix up cube-desktop to directly include the OVERC_COMMON_EXTENDED so that vim and others show up in the finalized rootfs.