### PR TITLE
cube-ctl: fix regression with c3 add and btrfs subvol creation

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -1095,7 +1095,7 @@ case "${cmd}" in
 	    out_dir="${container_dir}/"
 	fi
 
-	if [ -n "${track_containers}" -a ! -e ${out_dir} ]; then
+	if [ -n "${track_containers}" -a ! -e ${out_dir}${container_name} ]; then
 	    ${SBINDIR}/overc-ctl subvol ${container_name} -o ${out_dir}
 	fi
 	mkdir -p "${out_dir}/${container_name}/rootfs"


### PR DESCRIPTION
The commit e9e8c92d3a3ce0f46eee870d20d4c876494d303c (cube-ctl:
Optimize "c3 add" instantiation time) caused the btrfs sub volume code
to stop working because it was checking for the existence of the wrong
directory.

It should have checked out_dir=/opt/container + the container name.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>