### PR TITLE
zile: drop bbappend, fix now merged to meta-openembedded

### DIFF
--- a/meta-cube/recipes-extended/zile/zile_2.4.11.bbappend
+++ b/meta-cube/recipes-extended/zile/zile_2.4.11.bbappend
@@ -1,3 +1,0 @@
-do_install_prepend() {
-	mkdir -p ${D}${libdir}
-}


### PR DESCRIPTION
This was meant as a temporary fix until the fix was merged to
meta-openembedded. The fix has been merged in commit 64640f4e30d7 and
zile has since been uprev'd so we are getting a dangler WARNING, so
drop this.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>