### PR TITLE
cube-install: add uuidgen which is needed during the install

### DIFF
--- a/meta-cube/recipes-core/images/cube-install_1.0.bb
+++ b/meta-cube/recipes-core/images/cube-install_1.0.bb
@@ -81,6 +81,7 @@ PACKAGE_INSTALL += " \
     bzip2 \
     python \
     btrfs-tools \
+    util-linux-uuidgen \
     "
 
 # Required by cubeit


### PR DESCRIPTION
Commit 5920defadd3af689ccc32779ce80e2d157e72d94 [cube-ctl: Add a
randomized uuid for any created container] added the need to have
access to the uuidgen tool when completing an install. If you are
performing an install using the on-target installer the install will
complete but the missing tool will result in an error and
indeterminate issues associated with non-randomized uuids.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>