### PR TITLE
dockerclient: Add perl to RDEPENDS

### DIFF
--- a/meta-cube/recipes-devtools/go/dockerclient_git.bb
+++ b/meta-cube/recipes-devtools/go/dockerclient_git.bb
@@ -28,6 +28,6 @@ dockerclient_sysroot_preprocess () {
 }
 
 FILES_${PN} += "${prefix}/local/go/src/${PKG_NAME}/*"
-RDEPENDS_${PN} = "bash"
+RDEPENDS_${PN} = "bash perl"
 
 deltask compile_ptest_base


### PR DESCRIPTION
Fix new warning by latest bitbake:

ERROR: dockerclient-git-r0 do_package_qa: QA Issue: /usr/local/go/src/github.com/fsouza/go-dockerclient/src/import/.git/hooks/fsmonitor-watchman.sample contained in package dockerclient requires /usr/bin/perl, but no providers found in RDEPENDS_dockerclient? [file-rdeps]
ERROR: dockerclient-git-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: dockerclient-git-r0 do_package_qa: Function failed: do_package_qa
ERROR: Logfile of failure stored in: /ala-lpggp21/jwessel/wip/wr-core/build-intel-x86/tmp/work/core2-64-wrs-linux/dockerclient/git-r0/temp/log.do_package_qa.97102
ERROR: Task (/ala-lpggp21/jwessel/wip/wr-core/layers/meta-overc/meta-cube/recipes-devtools/go/dockerclient_git.bb:do_package_qa) failed with exit code '1'

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>