### PR TITLE
housekeeping: patch refreshes for systemd, ostree and screen

### DIFF
--- a/meta-cube/recipes-core/systemd/systemd/0001-systemd-make-udev-create-or-delete-device-nodes.patch
+++ b/meta-cube/recipes-core/systemd/systemd/0001-systemd-make-udev-create-or-delete-device-nodes.patch
@@ -1,4 +1,4 @@
-From 46c4dea510d216f79e38570cdfbdb4e6198a3beb Mon Sep 17 00:00:00 2001
+From adde13ff0d782152345716e53a35d96936955e77 Mon Sep 17 00:00:00 2001
 From: Bruce Ashfield <bruce.ashfield@windriver.com>
 Date: Thu, 26 Nov 2015 00:33:06 -0500
 Subject: [PATCH] systemd: make udev create or delete device nodes
@@ -13,13 +13,16 @@ it usually mount tmpfs to its /dev/, thus the "create" and
 Signed-off-by: fupan li <fupan.li@windriver.com>
 [bva: ported to systemd 225]
 Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+
 ---
- src/udev/udev-node.c |  102 ++++++++++++++++++++++++++++++++++++++++++++++++++-
+ src/udev/udev-node.c | 102 ++++++++++++++++++++++++++++++++++++++++++++++++++-
  1 file changed, 100 insertions(+), 2 deletions(-)
 
+diff --git a/src/udev/udev-node.c b/src/udev/udev-node.c
+index bb84588..77af381 100644
 --- a/src/udev/udev-node.c
 +++ b/src/udev/udev-node.c
-@@ -33,6 +33,62 @@
+@@ -35,6 +35,62 @@
  #include "string-util.h"
  #include "udev.h"
  
@@ -82,7 +85,7 @@ Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
  static int node_symlink(struct udev_device *dev, const char *node, const char *slink) {
          struct stat stats;
          char target[UTIL_PATH_SIZE];
-@@ -264,8 +320,13 @@ static int node_permissions_apply(struct
+@@ -265,8 +321,13 @@ static int node_permissions_apply(struct udev_device *dev, bool apply,
                  mode |= S_IFCHR;
  
          if (lstat(devnode, &stats) != 0) {
@@ -98,7 +101,7 @@ Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
          }
  
          if (((stats.st_mode & S_IFMT) != (mode & S_IFMT)) || (stats.st_rdev != devnum)) {
-@@ -359,13 +420,50 @@ void udev_node_add(struct udev_device *d
+@@ -359,13 +420,50 @@ void udev_node_add(struct udev_device *dev, bool apply,
  }
  
  void udev_node_remove(struct udev_device *dev) {
@@ -147,5 +150,5 @@ Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
 +            rmdir_parents(udev_device_get_devnode(dev), "/");
 +
          /* remove /dev/{block,char}/$major:$minor */
-         xsprintf(filename, "/dev/%s/%u:%u",
-                  streq(udev_device_get_subsystem(dev), "block") ? "block" : "char",
+         xsprintf_dev_num_path(filename,
+                               streq(udev_device_get_subsystem(dev), "block") ? "block" : "char",

--- a/meta-cube/recipes-extended/screen/screen/Add-nocheckpid-option.patch
+++ b/meta-cube/recipes-extended/screen/screen/Add-nocheckpid-option.patch
@@ -1,4 +1,4 @@
-From 42c69bb787a8aab540470808d595c724ca928c4d Mon Sep 17 00:00:00 2001
+From 15c58b3009c031cd6e8f599618912f9952b245eb Mon Sep 17 00:00:00 2001
 From: Jason Wessel <jason.wessel@windriver.com>
 Date: Sun, 3 Jul 2016 07:44:32 -0500
 Subject: [PATCH] Add -nocheckpid option
@@ -15,19 +15,27 @@ context.
 
 Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
 
+---
+ attacher.c   | 17 +++++++++++------
+ doc/screen.1 |  7 +++++++
+ help.c       |  1 +
+ screen.c     | 16 +++++++++++++---
+ socket.c     |  3 ++-
+ 5 files changed, 34 insertions(+), 10 deletions(-)
+
 diff --git a/attacher.c b/attacher.c
-index 1052549cbd57..2636ebf5579b 100644
+index 196993f..84bab28 100644
 --- a/attacher.c
 +++ b/attacher.c
-@@ -59,6 +59,7 @@ extern char HostName[];
- extern struct passwd *ppp;
- extern char *attach_tty, *attach_term, *LoginName, *preselect;
+@@ -64,6 +64,7 @@ extern bool attach_tty_is_in_new_ns;
+ /* Content of the tty symlink when attach_tty_is_in_new_ns == true. */
+ extern char attach_tty_name_in_ns[];
  extern int xflag, dflag, rflag, quietflag, adaptflag;
 +extern int nopidcheckflag;
  extern struct mode attach_Mode;
  extern struct NewWindow nwin_options;
  extern int MasterPid, attach_fd;
-@@ -307,11 +308,14 @@ int how;
+@@ -314,11 +315,14 @@ int how;
  
    debug2("Attach: uid %d euid %d\n", (int)getuid(), (int)geteuid());
    MasterPid = 0;
@@ -46,7 +54,7 @@ index 1052549cbd57..2636ebf5579b 100644
      }
    debug1("Attach decided, it is '%s'\n", SockPath);
    debug1("Attach found MasterPid == %d\n", MasterPid);
-@@ -459,7 +463,8 @@ static sigret_t
+@@ -466,7 +470,8 @@ static sigret_t
  AttacherSigInt SIGDEFARG
  {
    signal(SIGINT, AttacherSigInt);
@@ -56,7 +64,7 @@ index 1052549cbd57..2636ebf5579b 100644
    SIGRETURN;
  }
  
-@@ -627,7 +632,7 @@ Attacher()
+@@ -636,7 +641,7 @@ Attacher()
        alarm(15);
        pause();
        alarm(0);
@@ -66,7 +74,7 @@ index 1052549cbd57..2636ebf5579b 100644
  	  debug1("attacher: Panic! MasterPid %d does not exist.\n", MasterPid);
  	  AttacherPanic++;
 diff --git a/doc/screen.1 b/doc/screen.1
-index d3aab704d9b5..bdcdc895f33e 100644
+index 9eaf694..ff693e3 100644
 --- a/doc/screen.1
 +++ b/doc/screen.1
 @@ -299,6 +299,13 @@ Do not terminate the screen session when the final window is closed.  The
@@ -84,7 +92,7 @@ index d3aab704d9b5..bdcdc895f33e 100644
  Preselect a window. This is useful when you want to reattach to a
  specific window or you want to send a command via the \*Q-X\*U
 diff --git a/help.c b/help.c
-index fa95a4ae697a..092d98eaf2d6 100644
+index fa95a4a..092d98e 100644
 --- a/help.c
 +++ b/help.c
 @@ -88,6 +88,7 @@ void exit_with_usage(char *myname, char *message, char *arg)
@@ -96,10 +104,10 @@ index fa95a4ae697a..092d98eaf2d6 100644
    printf("-p window     Preselect the named window if it exists.\n");
    printf("-q            Quiet startup. Exits with non-zero return code if unsuccessful.\n");
 diff --git a/screen.c b/screen.c
-index 5553bf85f2ec..3b17d2395237 100644
+index e6739a9..a0d3204 100644
 --- a/screen.c
 +++ b/screen.c
-@@ -213,6 +213,7 @@ char *wlisttit;
+@@ -221,6 +221,7 @@ char *wlisttit;
  int auto_detach = 1;
  int iflag, rflag, dflag, lsflag, quietflag, wipeflag, xflag;
  int noexitflag;
@@ -107,7 +115,7 @@ index 5553bf85f2ec..3b17d2395237 100644
  int cmdflag;
  int queryflag = -1;
  int adaptflag;
-@@ -697,9 +698,18 @@ int main(int ac, char** av)
+@@ -702,9 +703,18 @@ int main(int ac, char** av)
              mflag = 1;
              break;
            case 'n':
@@ -130,10 +138,10 @@ index 5553bf85f2ec..3b17d2395237 100644
              break;
  
 diff --git a/socket.c b/socket.c
-index e464a62388c6..bad332c5062f 100644
+index 88c3dd8..faf32bb 100644
 --- a/socket.c
 +++ b/socket.c
-@@ -76,6 +76,7 @@ static void  AskPassword __P((struct msg *));
+@@ -77,6 +77,7 @@ static void  AskPassword __P((struct msg *));
  extern char *RcFileName, *extra_incap, *extra_outcap;
  extern int ServerSocket, real_uid, real_gid, eff_uid, eff_gid;
  extern int dflag, iflag, rflag, lsflag, quietflag, wipeflag, xflag;
@@ -141,7 +149,7 @@ index e464a62388c6..bad332c5062f 100644
  extern int queryflag;
  extern char *attach_tty, *LoginName, HostName[];
  extern struct display *display, *displays;
-@@ -862,7 +863,7 @@ struct win *wi;
+@@ -885,7 +886,7 @@ struct win *wi;
  	return -1;
      }
  
@@ -150,6 +158,3 @@ index e464a62388c6..bad332c5062f 100644
      {
        Msg(0, "Attach attempt with bad pid(%d)!", pid);
        return -1;
--- 
-2.11.0.rc2
-

--- a/meta-cube/recipes-support/ostree/ostree/0001-autogen.sh-fall-back-to-no-gtkdocize-if-it-is-there-.patch
+++ b/meta-cube/recipes-support/ostree/ostree/0001-autogen.sh-fall-back-to-no-gtkdocize-if-it-is-there-.patch
@@ -1,4 +1,4 @@
-From 6a025e5eb379ae4b813eedba43f622abd8244ade Mon Sep 17 00:00:00 2001
+From 854cae8bd29ca0d28c9eb22427cf4960414d2cb3 Mon Sep 17 00:00:00 2001
 From: Krisztian Litkey <kli@iki.fi>
 Date: Sat, 10 Sep 2016 22:15:21 +0300
 Subject: [PATCH] autogen.sh: fall back to no gtkdocize if it is there but
@@ -9,7 +9,7 @@ Subject: [PATCH] autogen.sh: fall back to no gtkdocize if it is there but
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/autogen.sh b/autogen.sh
-index 0f32089..00f5069 100755
+index 689bba8..1f7d14c 100755
 --- a/autogen.sh
 +++ b/autogen.sh
 @@ -25,7 +25,13 @@ EXTRA_DIST =
@@ -26,7 +26,4 @@ index 0f32089..00f5069 100755
 +}
  fi
  
- cd $olddir
--- 
-2.5.5
-
+ if ! test -f libglnx/README.md || ! test -f bsdiff/README.md; then


### PR DESCRIPTION
Now that bitbake reports when patches are applies with 'offset' or
'fuzz' we need to stay on top of patch refreshes. The following were
pickup up in a recent build and are being refreshed.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>