### PR TITLE
lxc: drop 'cgmanager' pkgconfig

### DIFF
--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -1,8 +1,4 @@
-# cgmanager is needed for running unpriv containers
-
-PACKAGECONFIG_append = " cgmanager templates seccomp"
-
-PACKAGECONFIG[cgmanager] = "--enable-cgmanager=yes,--enable-cgmanager=no,cgmanager,cgmanager"
+PACKAGECONFIG_append = " templates seccomp"
 
 SYSTEMD_AUTO_ENABLE_${PN}-setup = "enable"
 


### PR DESCRIPTION
The uprev of lxc to v3.0.0 (commit 0d7cfe86600b [lxc: uprev to v3.0.0]
in meta-virtualization) along with the upstream lxc commit
(0e7ff52c929c [tree-wide: remove cgmanager]) that was included in lxc
v3.0.0 is resulting in us getting this new warning when building lxc:

WARNING: lxc-3.0.1-r0 do_configure: QA Issue: lxc: configure was
  passed unrecognised options: --enable-cgmanager
  [unknown-configure-option]

Drop the pkgconfig for cgmanager. Since we moved OverC away from using
lxc for container management this upstream change and our adaptation
to it has no runtime consequences.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>