### PR TITLE
samba: delete useless bbappend to fix config error

### DIFF
--- a/meta-cube/recipes-connectivity/samba/samba_%.bbappend
+++ b/meta-cube/recipes-connectivity/samba/samba_%.bbappend
@@ -1,3 +1,0 @@
-DEPENDS += " quota"
-
-DEPENDS := "${@oe.utils.str_filter_out('ctdb','${DEPENDS}',d)}"


### PR DESCRIPTION
1. samba have add with-quota option, and disabled in meta-oe,
   so, this depend is not needed

2. samba have remove depend on ctdb, this line can also removed

Signed-off-by: Changqing Li <changqing.li@windriver.com>