### PR TITLE
packagegroup-builder: remove libssp per oe-core changes

### DIFF
--- a/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
@@ -84,9 +84,6 @@ RDEPENDS_packagegroup-builder-sdk = "\
     intltool \
     ldd \
     less \
-    libssp \
-    libssp-dev \
-    libssp-staticdev \
     libstdc++ \
     libstdc++-dev \
     libtool \


### PR DESCRIPTION
The oe-core made a change for gcc and then its builder package and the
same change is needed in order to properly build cube-builder.

----
commit 70c1154163761253346fb477ff362af6a838be09
Author: Khem Raj <raj.khem@gmail.com>
Date:   Mon Apr 30 06:37:17 2018 -0700

    packagegroup: Do not add libssp to SDK

    Libssp is only needed on non-glibc/non-musl systems
        Add rpcsvc-proto for rpcgen since its not part of glibc
	    anymore

----

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>