### PR TITLE
layer.conf: force use of our nanomsg recipe

### DIFF
--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -19,6 +19,9 @@ LAYERDEPENDS_cube = "core"
 # Grub2 is annoying but grub-legacy doesn't do ext4 w/o patches
 #PREFERRED_VERSION_grub = "0.97"
 
+# Don't use the recipe in meta-networking
+PREFERRED_VERSION_nanomsg = "1.0.0+git%"
+
 # Default is only a single getty on VC1
 SYSVINIT_ENABLED_GETTYS = "1 2 3 4 5 6"
 


### PR DESCRIPTION
After creating an image with a recent build I found that attempting to run commands like 'c3 list' were failing as nanocat was not found as part of the dom0 image. It turns out a recipe for nanocat has recently been added to meta-networking and this was being used instead of our recipe. The added recipe used nanomsg-tools as the main pkg name, otherwise this change would have gone unnoticed. Using PREFERRED_VERSION we force usage of our recipe for the time being.