### PR TITLE
linux-yocto-dev: don't force the loading of kvm* kernel modules

### DIFF
--- a/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -28,9 +28,6 @@ KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
 KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 
 KERNEL_MODULE_AUTOLOAD += "openvswitch"
-KERNEL_MODULE_AUTOLOAD += "kvm"
-KERNEL_MODULE_AUTOLOAD += "kvm-amd"
-KERNEL_MODULE_AUTOLOAD += "kvm-intel"
 
 KERNEL_FEATURES_append += "${@bb.utils.contains('DISTRO_FEATURES', 'aufs', ' features/aufs/aufs-enable.scc', '', d)}"
 KERNEL_FEATURES_append = " cfg/systemd.scc"


### PR DESCRIPTION
Similar to meta-virtualization commit commit eeb10ba17cb3
[linux-yocto: Fix systemd-modules-load.service start failure] we leave
the loading of the various kvm kernel modules to udev. If we continue
to force things as were before this change we will incur a 90 second
wait for the system to boot and the systemd-modules-load.service will
be marked as 'failed'.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>