### PR TITLE
linux-yocto-dev: Add nf_conntrack_ipv6 to load before openvswitch

### DIFF
--- a/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -27,7 +27,7 @@ KERNEL_FEATURES_append = " features/kvm/qemu-kvm-enable.scc"
 KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
 KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 
-KERNEL_MODULE_AUTOLOAD += "openvswitch"
+KERNEL_MODULE_AUTOLOAD += "nf_conntrack_ipv6 openvswitch"
 
 KERNEL_FEATURES_append += "${@bb.utils.contains('DISTRO_FEATURES', 'aufs', ' features/aufs/aufs-enable.scc', '', d)}"
 KERNEL_FEATURES_append = " cfg/systemd.scc"


### PR DESCRIPTION
In the v4.18 kernel there is a problem with the locking and init
sequence of the kernel modules such that openvswitch's init will hang
if the nf_conntrack_ipv6 is not already loaded.

The other option would have been to use kernel builtins instead of
kernel modules.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>