### PR TITLE
linux-yocto* bbappends: switch to using _append for kernel autoload

### DIFF
--- a/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-cube/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -27,7 +27,7 @@ KERNEL_FEATURES_append = " features/kvm/qemu-kvm-enable.scc"
 KERNEL_FEATURES_append = " features/tmpfs/tmpfs-posix-acl.scc"
 KERNEL_FEATURES_append = " features/cgroups/cgroups.scc"
 
-KERNEL_MODULE_AUTOLOAD += "nf_conntrack_ipv6 openvswitch"
+KERNEL_MODULE_AUTOLOAD_append += "nf_conntrack_ipv6 openvswitch"
 
 KERNEL_FEATURES_append += "${@bb.utils.contains('DISTRO_FEATURES', 'aufs', ' features/aufs/aufs-enable.scc', '', d)}"
 KERNEL_FEATURES_append = " cfg/systemd.scc"

--- a/meta-cube/recipes-kernel/linux/linux-yocto.inc
+++ b/meta-cube/recipes-kernel/linux/linux-yocto.inc
@@ -19,7 +19,7 @@ KERNEL_FEATURES_append = " cfg/systemd.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext3.scc"
 KERNEL_FEATURES_append = " cfg/fs/ext2.scc"
 
-KERNEL_MODULE_AUTOLOAD += "nf_conntrack_ipv6 openvswitch"
+KERNEL_MODULE_AUTOLOAD_append += "nf_conntrack_ipv6 openvswitch"
 
 # we trust the latest!
 SRCREV_machine_${MACHINE}="${AUTOREV}"


### PR DESCRIPTION
Some x86 and ARM BSP's set:
   KERNEL_MODULE_AUTOLOAD_intel-x86-common = "...modules..."
   KERNEL_MODULE_AUTOLOAD_armv7a = "...modules..."

This was overriding the "KERNEL_MODULE_AUTOLOAD +=" directive in the
recipe meta-cube extensions which was causing openvswitch not to load
properly.  The simple fix is to use the _append mechanism just like
the KERNEL_FEATURE_append.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>