### PR TITLE
Remove dom1 ... add cube-vrf

### DIFF
--- a/README.install
+++ b/README.install
@@ -7,8 +7,6 @@ functionality. The current cubes are:
  - dom0: provides control services to the platform and is responsible for
          launching other containers in the system. Dom0 is not manipulated
          by non admin users.
- - dom1: provides system services (such as ntpd, etc) to the platform. This
-         is not used by a typical user.
  - cube-desktop: provides full 'enterprise' functionality. This includes man pages,
          development tools, graphical desktop, etc. This domain is the primary
          environment for most users.
@@ -48,7 +46,7 @@ Modify local.conf with following settings:
 Clone the layers described in the meta-overc/README, and build the images
 mentioned in the overview:
 
-  % bitbake cube-dom0 cube-dom1 cube-desktop cube-essential cube-builder
+  % bitbake cube-dom0 cube-desktop cube-essential cube-builder
 
 This will take some time, since multiple images and configurations are
 being build and assembled.
@@ -74,7 +72,7 @@ OverC installer
 The OverC installer must be assembled from build artifacts, and provides a 
 bootable USB stick that is capable of installing to a hard disk on the 
 target system. It also completes required installation and configuration of
-the components that make up the core system (dom0, dom1, cube-desktop, essential).
+the components that make up the core system (dom0, cube-desktop, essential).
 
 The OverC installer is available from the following repository:
 

--- a/README.install
+++ b/README.install
@@ -7,6 +7,11 @@ functionality. The current cubes are:
  - dom0: provides control services to the platform and is responsible for
          launching other containers in the system. Dom0 is not manipulated
          by non admin users.
+ - cube-vrf: provides virtual routing and forwarding (vrf) functions to the
+         system. By running an OpenVSwitch (ovs) bridge along with other
+         networking services. Containers will 'insert' one end of a veth pair
+         into the cube-vrf, via startup hooks, to join the cube LAN to provide
+         minimal networking to containers.
  - cube-desktop: provides full 'enterprise' functionality. This includes man pages,
          development tools, graphical desktop, etc. This domain is the primary
          environment for most users.
@@ -46,7 +51,7 @@ Modify local.conf with following settings:
 Clone the layers described in the meta-overc/README, and build the images
 mentioned in the overview:
 
-  % bitbake cube-dom0 cube-desktop cube-essential cube-builder
+  % bitbake cube-dom0 cube-vrf cube-desktop cube-essential cube-builder
 
 This will take some time, since multiple images and configurations are
 being build and assembled.
@@ -72,7 +77,8 @@ OverC installer
 The OverC installer must be assembled from build artifacts, and provides a 
 bootable USB stick that is capable of installing to a hard disk on the 
 target system. It also completes required installation and configuration of
-the components that make up the core system (dom0, cube-desktop, essential).
+the components that make up the core system (dom0, cube-vrf, cube-desktop,
+essential).
 
 The OverC installer is available from the following repository:
 

--- a/docs/README.unprivileged_container
+++ b/docs/README.unprivileged_container
@@ -24,8 +24,7 @@ to add the subuid property to your container specified in the
 HDINSTALL_CONTAINERS configure line, e.g.
 
 HDINSTALL_CONTAINERS="${ARTIFACTS_DIR}/cube-dom0-genericx86-64.tar.bz2:vty=2:mergepath=/usr,essential \
-                      ${ARTIFACTS_DIR}/cube-dom1-genericx86-64.tar.bz2:vty=3:mergepath=/usr,essential,dom0 \
-                      ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=4:net=1:mergepath=/usr,essential,dom0,dom1 \
+                      ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=4:net=1:mergepath=/usr,essential,dom0 \
                       ${ARTIFACTS_DIR}/cube-server-genericx86-64.tar.bz2:subuid=800000"
 
 The value of the subuid will be the subuid used by the root user within the

--- a/docs/README.unprivileged_container
+++ b/docs/README.unprivileged_container
@@ -24,7 +24,8 @@ to add the subuid property to your container specified in the
 HDINSTALL_CONTAINERS configure line, e.g.
 
 HDINSTALL_CONTAINERS="${ARTIFACTS_DIR}/cube-dom0-genericx86-64.tar.bz2:vty=2:mergepath=/usr,essential \
-                      ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=4:net=1:mergepath=/usr,essential,dom0 \
+                      ${ARTIFACTS_DIR}/cube-vrf-genericx86-64.tar.bz2:net=vrf \
+                      ${ARTIFACTS_DIR}/cube-desktop-genericx86-64.tar.bz2:vty=3:net=1:mergepath=/usr,essential,dom0 \
                       ${ARTIFACTS_DIR}/cube-server-genericx86-64.tar.bz2:subuid=800000"
 
 The value of the subuid will be the subuid used by the root user within the

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
@@ -7,6 +7,7 @@ IMAGE_DIR=/root/images
 
 UPSTREAM_URL=http://openlinux.windriver.com/overc/images/genericx86-64/
 DOM0_IMAGE=cube-dom0-genericx86-64.tar.bz2
+VRF_IMAGE=cube-vrf-genericx86-64.tar.bz2
 DOME_IMAGE=cube-desktop-genericx86-64.tar.bz2
 
 usage() {
@@ -88,10 +89,11 @@ log_error() {
 # Expected format we need to parse:
 #
 # root@cube-dom0:~# /usr/sbin/c3 list
-# name          type  status   attributes  addresses
-# ----          ----  ------   ----------  ---------
-# cube-desktop  oci   running  --          192.168.42.200
-# dom0          cube  running  vrf         netprime        192.168.42.1,10.0.2.15
+# name          type    status   attributes  addresses
+# ----          ----    ------   ----------  ---------
+# cube-desktop  runc    running  --          192.168.42.200
+# dom0          pflask  running  netprime    192.168.42.1,192.168.42.3,10.0.2.15
+# vrf           pflask  running  vrf         192.168.42.4
 #
 #     return value:
 #        0: does not exist
@@ -140,6 +142,9 @@ activate() {
 	case "${container}" in
 		dom0)
 			rootfs=$IMAGE_DIR/$DOM0_IMAGE
+			;;
+		vrf)
+			rootfs=$IMAGE_DIR/$VRF_IMAGE
 			;;
 		*desktop)
 			rootfs=$IMAGE_DIR/$DOME_IMAGE
@@ -261,7 +266,7 @@ pull_single_image() {
 
 pull_image() {
 	local url
-	for url in $DOM0_IMAGE $DOME_IMAGE; do
+	for url in $DOM0_IMAGE $VRF_IMAGE $DOME_IMAGE; do
 		pull_single_image $UPSTREAM_URL/$url
 	done
 }

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/container-scripts/dom0
@@ -7,7 +7,6 @@ IMAGE_DIR=/root/images
 
 UPSTREAM_URL=http://openlinux.windriver.com/overc/images/genericx86-64/
 DOM0_IMAGE=cube-dom0-genericx86-64.tar.bz2
-DOM1_IMAGE=cube-dom1-genericx86-64.tar.bz2
 DOME_IMAGE=cube-desktop-genericx86-64.tar.bz2
 
 usage() {
@@ -93,7 +92,6 @@ log_error() {
 # ----          ----  ------   ----------  ---------
 # cube-desktop  oci   running  --          192.168.42.200
 # dom0          cube  running  vrf         netprime        192.168.42.1,10.0.2.15
-# dom1          oci   running  --          192.168.42.201
 #
 #     return value:
 #        0: does not exist
@@ -142,9 +140,6 @@ activate() {
 	case "${container}" in
 		dom0)
 			rootfs=$IMAGE_DIR/$DOM0_IMAGE
-			;;
-		dom1)
-			rootfs=$IMAGE_DIR/$DOM1_IMAGE
 			;;
 		*desktop)
 			rootfs=$IMAGE_DIR/$DOME_IMAGE
@@ -266,7 +261,7 @@ pull_single_image() {
 
 pull_image() {
 	local url
-	for url in $DOM0_IMAGE $DOM1_IMAGE $DOME_IMAGE; do
+	for url in $DOM0_IMAGE $DOME_IMAGE; do
 		pull_single_image $UPSTREAM_URL/$url
 	done
 }

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/test/test.sh
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/test/test.sh
@@ -47,10 +47,9 @@ echo "REST server started at pid: $svr_pid"
 
 #################################################
 # test status
-# on bootup, dom0, dom1 and cube-desktop containers should be active
+# on bootup, dom0 and cube-desktop containers should be active
 #################################################
 test_container_status dom0 3
-test_container_status dom1 3
 test_container_status cube-desktop 3
 test_container_status invalid_container 0
 

--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/test/test.sh
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/test/test.sh
@@ -47,9 +47,10 @@ echo "REST server started at pid: $svr_pid"
 
 #################################################
 # test status
-# on bootup, dom0 and cube-desktop containers should be active
+# on bootup, dom0, vrf and cube-desktop containers should be active
 #################################################
 test_container_status dom0 3
+test_container_status vrf 3
 test_container_status cube-desktop 3
 test_container_status invalid_container 0
 


### PR DESCRIPTION
Even though we have updated the OverC framework to drop the concept of dom1 and add the cube-vrf container we have several references to dom1 in docs and scripts which have yet to be removed. Likewise we don't have references to cube-vrf where they should exist.