### PR TITLE
cube-netconfig, cube-network: Optimize and fix wild card devices

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
@@ -49,7 +49,24 @@ get_vrf_container() {
 
 if [ "${action}" = "netprime" ]; then
     netdevs=$(cat .cube.device.network)
+
+    # Expand any network+ args
+    netdevsexp=""
+    nds=`nsenter -t ${pid} -n ip -o link  |awk -F: '{print $2}'`
     for n in ${netdevs}; do
+        if [ "${n}" = "${n/+/}" ] ; then
+            netdevsexp="$n $netdevsexp"
+        else
+            device=$(echo ${n} | cut -f1 -d+)
+            for nd in $nds; do
+                if [ "$nd" != "${nd#$device}" ] ; then
+                    netdevsexp="$nd:$nd $netdevsexp"
+                fi
+            done
+        fi
+    done
+
+    for n in ${netdevsexp}; do
 	echo ${n} | grep -q veth
 	if [ $? -ne 0 ]; then
 	    # we have a real device

--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -409,12 +409,13 @@ if [ "${action}" = "up" ]; then
 
 	# Expand any network+ args
 	netdevsexp=""
+	nds=`ip -o link  |awk -F: '{print $2}'`
 	for n in ${netdevs}; do
             if [ "${n}" = "${n/+/}" ] ; then
                 netdevsexp="$n $netdevsexp"
             else
                 device=$(echo ${n} | cut -f1 -d+)
-                for nd in `ip -o link  |awk -F: '{print $2}'`; do
+                for nd in $nds; do
                     if [ "$nd" != "${nd#$device}" ] ; then
                         netdevsexp="$nd:$nd $netdevsexp"
                     fi


### PR DESCRIPTION
The wild card device expansion only needs to run the ip link command a
single time.  The cube-netconfig was missing the wildcard expansion
code, which caused it to improperly send a wildcard character in some
networking commands.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>