### PR TITLE
cube-network: Move dhclient for netprime to netprime pid space

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
@@ -71,7 +71,9 @@ if [ "${action}" = "netprime" ]; then
 	    ##       The problem is. if we leave this self managed, we cannot set the DNS information
 	    ##       on the VRF and that's an issue.
 	    command="dhclient -sf /usr/sbin/dhclient-script.container -e CONTAINER=${cubename} --no-pid ${device} >> /dev/null 2>&1"
-	    eval nsenter -t ${pid} -n -- ${command}
+	    # Run the command in the network prime's pid space such that when
+	    # the container is killed so is the command, should it be a daemon
+	    eval nsenter -p -t ${pid} -n -- ${command}
 	    if [ -e "/etc/resolv.conf.${cubename}" ]; then
 		# the VRF (currently dom0) routes our DNS traffic, so we need to get
 		# this captured config into it's dnsmasq.conf


### PR DESCRIPTION
We want to make sure that anytime the netprime container dies
ungracefully, or is killed intententionally that all its associated
processes are also reaped automatically.

This solves the problem where the netprime container was restarted and
the stop hook did not run which would have properly cleaned up the
stray dhclient process.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>