### PR TITLE
cube-network: Work with /var/run/resolv.conf

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -478,8 +478,8 @@ if [ "${action}" = "up" ]; then
     if [ -f "cube.network.nameserver" ]; then
 	nameserver=$(cat cube.network.nameserver)
     fi
-    nsenter -t ${pid} -m sh -c "rm -f /etc/resolv.conf"
-    nsenter -t ${pid} -m sh -c "echo nameserver ${nameserver} > /etc/resolv.conf"
+    # On a system with /var/run the /etc/resolv.conf will be a volatile
+    nsenter -t ${pid} -m sh -c "if [ -e /var/run ] ; then echo nameserver ${nameserver} > /var/run/resolv.conf; ln -sf /var/run/resolv.conf /etc/resolv.conf; else rm -f /etc/resolv.conf; echo nameserver ${nameserver} > /etc/resolv.conf; fi"
 
     # and now some network namespace accounting
     mkdir -p /var/run/netns


### PR DESCRIPTION
On user space containers configured with a volatile /etc/resolv.conf
such as debian and recent oe-core builds. It will erase what ever is
in /etc/resolv.conf during the system startup.  The mechanism can be
turned off by simply creating the /var/run/resolv.conf in the hook.

Prior to this change the hook would race against the user space
startup and dns service could fail.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>