### PR TITLE
Use tini in the cube-vrf container

### DIFF
--- a/meta-cube/recipes-containers/tini/tini_%.bbappend
+++ b/meta-cube/recipes-containers/tini/tini_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append() {
+    install -d ${D}/sbin
+    ln -sfr ${D}${bindir}/docker-init ${D}/sbin/init
+}

--- a/meta-cube/recipes-core/images/cube-vrf_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-vrf_0.1.bb
@@ -12,6 +12,7 @@ IMAGE_INSTALL += " \
     iproute2 \
     dnsmasq \
     base-passwd \
+    tini \
     vrf-init \
     bash \
 "

--- a/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
@@ -126,7 +126,7 @@ if [ "${action}" = "netprime" ]; then
 		vrf_name=$(get_vrf_container)
 		vrf_pid=$(cat /opt/container/${vrf_name}/.cube.pid)
 
-		nsenter -t ${vrf_pid} -m -n -u -i -p -C --preserve-credentials -- /sbin/init restart
+		nsenter -t ${vrf_pid} -m -n -u -i -p -C --preserve-credentials -- /sbin/vrf-init restart
 	    fi
 	
 	    # We need to track the pids of dhclient so it can be killed later if the

--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -56,7 +56,7 @@ get_cube_vrf_pid() {
     cube_vrf_ppid=$(ps -ef|grep -E "[0-9]+\ +1\ .*pflask.*cube-vrf"|grep -v grep|awk '{print $2}')
     # There can be multiple pids associated with the ppid at startup but we only care about
     # the one either launching or running '/sbin/init', so filter accordingly
-    echo $(ps -ef|grep -E "[0-9]+\ +${cube_vrf_ppid}\ +.*/sbin/init$"|grep -v grep|awk '{print $2}')
+    echo $(ps -ef|grep -E "[0-9]+\ +${cube_vrf_ppid}\ +.*/sbin/init"|grep -v grep|awk '{print $2}')
 }
 
 get_vrf_container() {

--- a/meta-cube/recipes-support/overc-utils/source/cube-cfg
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cfg
@@ -1011,7 +1011,7 @@ convert_base_config_to_cube()
     fi
 
     # what is the executable we are running ?
-    app=$(jq -r  '.process.args | .[]' config.json)
+    app=$(jq -j  '.process.args | join(" ")' config.json)
 
     # and the root directory (to be appended to the current working dir)
     rootfs=$(jq -r  '.root.path'  config.json)

--- a/meta-cube/recipes-support/vrf-init/files/vrf-init
+++ b/meta-cube/recipes-support/vrf-init/files/vrf-init
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# TODO: move to a simple init system, like docker's tiny-init, since we will
-#       miss some reaping / exiting capabilities with this
+# This is usually called by tini 'init' for startup but called
+# directly for restart.
 if [ "$1" == "start" ] || [ -z "$1" ]; then
     # Ensure we have some prerequisites in place
     mkdir -p /var/run/openvswitch

--- a/meta-cube/recipes-support/vrf-init/vrf-init_0.1.bb
+++ b/meta-cube/recipes-support/vrf-init/vrf-init_0.1.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
 
 do_install() {
     install -d ${D}/sbin
-    install -m 0755 ${WORKDIR}/vrf-init ${D}/sbin/init
+    install -m 0755 ${WORKDIR}/vrf-init ${D}/sbin/vrf-init
 
     install -d ${D}/${prefix}
     install -d ${D}/${bindir}


### PR DESCRIPTION
Adds zombie reaping and proper signal handling to the cube-vrf. You need to also have the overc-installer commit which adds the 'app' attribute. If testing locally be sure to copy cube-cfg to the installer sbin dir. I linked the docker-init to /sbin/init since I prefer to use this standard, though I suspect some folks would bash me for breaking some filesystem conventions with this but remember tini will be in containers and not standard root filesystems so we shouldn't have to worry about mount order etc...