### PR TITLE
cube-vrf: Use /etc/vrf-resolv.conf to establish dns forwarding dynami…

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
@@ -82,16 +82,9 @@ if [ "${action}" = "netprime" ]; then
 		    vrf=$(cat .cube.vrf.name)
 		fi
 
-		# clean up, before we add our options
-		sed '/no-resolv/d' -i /opt/container/${vrf}/rootfs/etc/dnsmasq.conf
-		sed '/server=.*/d' -i /opt/container/${vrf}/rootfs/etc/dnsmasq.conf
-
-		sed '/search.*/d' -i /etc/resolv.conf.${cubename}
-		sed 's/nameserver /server=/g' -i /etc/resolv.conf.${cubename}
-
-		echo "# servers in this file are managed by the cube-netconfig hook. Any changes will be overwritten" >> /opt/container/${vrf}/rootfs/etc/dnsmasq.conf
-		echo "no-resolv" >> /opt/container/${vrf}/rootfs/etc/dnsmasq.conf
-		cat /etc/resolv.conf.${cubename} >> /opt/container/${vrf}/rootfs/etc/dnsmasq.conf
+		# Write out DNS forwarding information into the cube-vrf
+		echo "# servers in this file are managed by the cube-netconfig hook. Any changes will be overwritten" > /opt/container/${vrf}/rootfs/etc/vrf-resolv.conf
+		cat /etc/resolv.conf.${cubename} >> /opt/container/${vrf}/rootfs/etc/vrf-resolv.conf
 
 		# These may need to be refined, but they nat and forward and DNS
 		# traffic from the netprime (.1) to the VRF (currently "the vrf" @ .4)
@@ -122,11 +115,6 @@ if [ "${action}" = "netprime" ]; then
 		    nsenter -t ${pid} -n --preserve-credentials -- iptables -t nat -I POSTROUTING -d 192.168.42.0/24 -j MASQUERADE
 		fi
 
-		# Enter vrf and restart dnsmasq
-		vrf_name=$(get_vrf_container)
-		vrf_pid=$(cat /opt/container/${vrf_name}/.cube.pid)
-
-		nsenter -t ${vrf_pid} -m -n -u -i -p -C --preserve-credentials -- /sbin/init restart
 	    fi
 	
 	    # We need to track the pids of dhclient so it can be killed later if the

--- a/meta-cube/recipes-support/vrf-init/files/vrf-init
+++ b/meta-cube/recipes-support/vrf-init/files/vrf-init
@@ -6,7 +6,7 @@ if [ "$1" == "start" ] || [ -z "$1" ]; then
     # Ensure we have some prerequisites in place
     mkdir -p /var/run/openvswitch
 
-    /usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service
+    /usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service --resolv-file=/etc/vrf-resolv.conf
 
     # We can't exit else the container will be destroyed
     sleep infinity
@@ -18,5 +18,5 @@ if [ "$1" == "restart" ]; then
 	kill -9 ${dnspid}
     fi
 
-    /usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service
+    /usr/bin/dnsmasq -x /run/dnsmasq.pid -7 /etc/dnsmasq.d --local-service --resolv-file=/etc/vrf-resolv.conf
 fi


### PR DESCRIPTION
…cally

There is a race condiditon from the time dnsmasq is terminated to the
time it can be restarted and bind to its ports and start forwarding
DNS queries.

We can solve the problem by using an alternate file such as
/etc/vrf-resolv.conf to take the place of resolv.conf.  The dnsmasq
server will use an inotify event to trigger a reload of the dns
fowarding information to resolve queries any time the file is
rewritten.  This means we no longer need to restart the process or
pass a signal.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>