### PR TITLE
mutt patch refresh

### DIFF
--- a/meta-cube/recipes-extended/mutt/mutt-1.10.1/docs-use-sysroot-for-CPP_FLAGS.patch
+++ b/meta-cube/recipes-extended/mutt/mutt-1.10.1/docs-use-sysroot-for-CPP_FLAGS.patch
@@ -1,7 +1,7 @@
-From f1749b8bd73a32c4f0c3f1de205487d4843521a4 Mon Sep 17 00:00:00 2001
+From b0b338d3647430d586445f03084f327ef692f4a2 Mon Sep 17 00:00:00 2001
 From: Bruce Ashfield <bruce.ashfield@windriver.com>
 Date: Wed, 8 Apr 2015 15:55:05 -0400
-Subject: [PATCH 1/2] docs: use sysroot for CPP_FLAGS
+Subject: [PATCH] docs: use sysroot for CPP_FLAGS
 
 Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
 ---
@@ -9,11 +9,11 @@ Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/doc/Makefile.am b/doc/Makefile.am
-index 4a6e475b6368..19e3a11b8b4c 100644
+index bc8f856..9346696 100644
 --- a/doc/Makefile.am
 +++ b/doc/Makefile.am
-@@ -3,7 +3,7 @@ subdir = doc
- DSLROOT = @DSLROOT@
+@@ -6,7 +6,7 @@ AUTOMAKE_OPTIONS = 1.6 foreign
+ subdir = doc
  
  DEFS = -DSYSCONFDIR=\"$(sysconfdir)\" -DBINDIR=\"$(bindir)\" -DHAVE_CONFIG_H=1
 -AM_CPPFLAGS = -I. -I.. -I$(includedir) -I$(top_srcdir)
@@ -22,5 +22,5 @@ index 4a6e475b6368..19e3a11b8b4c 100644
  MAKEDOC_CPP = $(CPP) $(AM_CPPFLAGS) $(DEFS) $(CPPFLAGS) -D_MAKEDOC -C
  
 -- 
-2.1.0
+2.7.4
 

--- a/meta-cube/recipes-extended/mutt/mutt-1.10.1/makedoc.patch
+++ b/meta-cube/recipes-extended/mutt/mutt-1.10.1/makedoc.patch
@@ -1,8 +1,8 @@
-Index: mutt-1.5.19/doc/Makefile.am
-===================================================================
---- mutt-1.5.19.orig/doc/Makefile.am
-+++ mutt-1.5.19/doc/Makefile.am
-@@ -7,7 +7,7 @@ AM_CPPFLAGS = -I. -I.. -I$(includedir) -
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 9346696..f021999 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -10,7 +10,7 @@ AM_CPPFLAGS = -I. -I.. -I=$(includedir) -I$(top_srcdir)
  
  MAKEDOC_CPP = $(CPP) $(AM_CPPFLAGS) $(DEFS) $(CPPFLAGS) -D_MAKEDOC -C
  
@@ -10,11 +10,11 @@ Index: mutt-1.5.19/doc/Makefile.am
 +makedoc : $(makedoc_SOURCES)
  
  EXTRA_DIST = dotlock.man		\
- 	muttbug.man			\
-Index: mutt-1.5.19/doc/makedoc.c
-===================================================================
---- mutt-1.5.19.orig/doc/makedoc.c
-+++ mutt-1.5.19/doc/makedoc.c
+         smime_keys.man                  \
+diff --git a/doc/makedoc.c b/doc/makedoc.c
+index 1fcbc24..c5ca6e3 100644
+--- a/doc/makedoc.c
++++ b/doc/makedoc.c
 @@ -51,7 +51,7 @@
  #ifndef HAVE_STRERROR
  #ifndef STDC_HEADERS


### PR DESCRIPTION
This patch was missed during the latest mega merge. Originally this was ahead of the mutt version uprev so a slight update to account for this being applied afterwards now.