### PR TITLE
grub: enable grub-native for use with the overc-install

### DIFF
--- a/meta-cube/recipes-bsp/grub/grub_2.02.bbappend
+++ b/meta-cube/recipes-bsp/grub/grub_2.02.bbappend
@@ -1,2 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += "file://grub-enable-serial-console-by-default.patch"
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
overc-install wants to be able to use grub-native, but not all host systems have this.  Add grub-native support.