### PR TITLE
Fixes for the read-only root name space

### DIFF
--- a/meta-cube/recipes-core/images/cube-essential_0.3.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.3.bb
@@ -102,10 +102,6 @@ EOF
 ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs", "read_only_essential; ", "", d)}'
 
 read_only_essential () {
-    echo "none	/etc/openvswitch	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
-    mkdir -p ${IMAGE_ROOTFS}/opt/container
-    echo "none	/opt/container	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
-    echo "none	/var/lib/misc	tmpfs	defaults	1	1" >> ${IMAGE_ROOTFS}/etc/fstab
     if [ -e ${IMAGE_ROOTFS}/etc/hosts ]; then
         mv ${IMAGE_ROOTFS}/etc/hosts ${IMAGE_ROOTFS}/etc/hosts0
         ln -s ../run/systemd/resolve/hosts ${IMAGE_ROOTFS}/etc/hosts

--- a/meta-cube/recipes-support/essential-init/files/essential-autostart
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart
@@ -1,12 +1,29 @@
 #!/bin/bash
 
+# Check that /var/log/journal is writeable, else set it up
+touch /var/log/journal
+if [ $? != 0 ] ; then
+    mkdir -p /opt/container/.rootns/var/log/journal
+    mount -o bind /opt/container/.rootns/var/log/journal /var/log/journal
+fi
+
+# Check that /var/lib/cube is writeable, else set it up
+touch /var/lib/cube
+if [ $? != 0 ] ; then
+    mkdir -p /opt/container/.rootns/var/lib/cube
+    mount -o bind /opt/container/.rootns/var/lib/cube /var/lib/cube
+fi
+
+# Create directories in case they have not been setup yet
+mkdir -p /var/lib/cube/all /var/lib/cube/essential /var/lib/cube/local
+
 if [ "$1" = "stop" ] ; then
     pid=`/bin/machinectl show dom0 -p Leader --value`
     if [ ! -n "$pid" ] ; then
 	exit 0
     fi
 
-    # Graceful shutdown required if root name space is shutting down
+
     if systemctl list-jobs shutdown.target | grep -q shutdown.target ; then
 	kill -INT $pid
     else

--- a/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-netconfig
@@ -87,11 +87,11 @@ if [ "${action}" = "netprime" ]; then
 	    ##
 	    ##       The problem is. if we leave this self managed, we cannot set the DNS information
 	    ##       on the VRF and that's an issue.
-	    command="dhclient -sf /usr/sbin/dhclient-script.container -e CONTAINER=${cubename} --no-pid ${device} >> /dev/null 2>&1"
+	    command="dhclient -lf /opt/container/${cubename}/rootfs/var/lib/dhcp/dhclient.leases -sf /usr/sbin/dhclient-script.container -e CONTAINER=${cubename} --no-pid ${device} >> /dev/null 2>&1"
 	    # Run the command in the network prime's pid space such that when
 	    # the container is killed so is the command, should it be a daemon
 	    eval nsenter -p -t ${pid} -n -- ${command}
-	    if [ -e "/etc/resolv.conf.${cubename}" ]; then
+	    if [ -e "/opt/container/${cubename}/resolv.conf" ]; then
 		# the VRF (currently dom0) routes our DNS traffic, so we need to get
 		# this captured config into it's dnsmasq.conf
 
@@ -103,7 +103,7 @@ if [ "${action}" = "netprime" ]; then
 
 		# Write out DNS forwarding information into the cube-vrf
 		echo "# servers in this file are managed by the cube-netconfig hook. Any changes will be overwritten" > /opt/container/${vrf}/rootfs/etc/vrf-resolv.conf
-		cat /etc/resolv.conf.${cubename} >> /opt/container/${vrf}/rootfs/etc/vrf-resolv.conf
+		cat /opt/container/${cubename}/resolv.conf >> /opt/container/${vrf}/rootfs/etc/vrf-resolv.conf
 
 		# These may need to be refined, but they nat and forward and DNS
 		# traffic from the netprime (.1) to the VRF (currently "the vrf" @ .4)

--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -363,8 +363,8 @@ if [ "${action}" = "up" ]; then
 	    mkdir -p /opt/container/${cname}/rootfs/var/lib/dhcp
 	fi
 	eval nsenter -t ${pid} -n -- ${command}
-	if [ -e "/etc/resolv.conf.${cname}" ]; then
-	    mv /etc/resolv.conf.${cname} /opt/container/${cname}/rootfs/etc/resolv.conf
+	if [ -e "/opt/container/${cname}/resolv.conf" ]; then
+	    mv /opt/container/${cname}/resolv.conf /opt/container/${cname}/rootfs/etc/resolv.conf
 	fi
 	#nsenter -t ${pid} -n --preserve-credentials dhclient ${veth_name}
 	primary_ip=$(nsenter -t ${pid} -n ip -o -4 addr list ${veth_name} | awk '{print $4}' | cut -d/ -f1)

--- a/meta-cube/recipes-support/overc-conftools/source/dhclient-script.container
+++ b/meta-cube/recipes-support/overc-conftools/source/dhclient-script.container
@@ -27,9 +27,9 @@ ip=/sbin/ip
 
 make_resolv_conf() {
   if [ x"$CONTAINER" != x ]; then
-	suffix=$CONTAINER
+	con_dir=/opt/container/$CONTAINER
   else	
-	suffix=foo
+	con_dir=/tmp
   fi
   if [ x"$new_domain_name_servers" != x ]; then
     resolv_conf=""
@@ -45,7 +45,7 @@ make_resolv_conf() {
       resolv_conf="${resolv_conf}nameserver ${nameserver}\n"
     done
 
-    echo -e "${resolv_conf}" > /etc/resolv.conf.$suffix
+    echo -e "${resolv_conf}" > ${con_dir}/resolv.conf
   elif [ "x${new_dhcp6_name_servers}" != x ] ; then
     resolv_conf=""
 
@@ -65,7 +65,7 @@ make_resolv_conf() {
       resolv_conf="${resolv_conf}nameserver ${nameserver}$zone_id\n"
     done
 
-    echo -e "${resolv_conf}" > /etc/resolv.conf.$suffix
+    echo -e "${resolv_conf}" > ${con_dir}/resolv.conf
   fi
 }
 

--- a/meta-cube/recipes-support/overc-utils/source/cube-cfg
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cfg
@@ -932,6 +932,7 @@ if [ -e "/opt/container/${container_name}/cube.console.mgr.runonce" ]; then
 else
     console_mgr=\$(cat /opt/container/${container_name}/cube.console.mgr)
 fi
+mkdir -p /var/lib/cube/${container_name}
 if [ "\${console_mgr}" = "tty" ] || [ "\${console_mgr}" = "screen-tty" ]; then
     if [ "\${args}" != "attach" ] ; then
 	rm -f /var/lib/cube/${container_name}/dtach-sock \


### PR DESCRIPTION
Tested with and without:
echo 'OVERC_ESSENTIAL_MODE="read-only"' >> conf/local.conf
