### PR TITLE
W2

### DIFF
--- a/docs/README.firmware
+++ b/docs/README.firmware
@@ -48,6 +48,12 @@ additions/removals in dom0's '/lib/firmware' will be reflected in
 cube-essential's '/lib/firmware' after a sync, but not the other way
 around.
 
+NOTE ABOUT OPTIMIZATIONS:
+By default /var/lib/cube/essential/lib/firmware is a link to
+/opt/container/dom0/rootfs/lib/firmware.  This is a short circuit
+which is put in place to allow for just a single copy of the firmware.
+If you replace the link with a directory a second copy of the firmware
+will be created.
 
 Syncing
 -------------------------
@@ -59,16 +65,19 @@ look like one of the following:
 1)
   a) replace dom0 (with the new image containing '/lib/firmware' updates)
   b) restart dom0 (the dom0-ctl-core will automatically sync firmware)
+     * step b) is not needed if you are using the short circuit symlink
   c) reload cube-essential kernel modules affected by firmware updates
 
 2)
   a) update dom0 (with firmware related package updates)
   b) run '/etc/dom0.d/firmware-sync' to complete a sync
+     * step b) is not needed if you are using the short circuit symlink
   c) reload cube-essential kernel modules affected by firmware updates
 
 3)
   a) update or replace dom0 (including firmware updates)
   b) run '/etc/dom0.d/firmware-sync' to complete a sync
+     * step b) is not needed if you are using the short circuit symlink
   c) reboot the system
 
 NOTE that it may not always be possible to complete an update, which

--- a/meta-cube/recipes-core/images/cube-essential_0.3.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.3.bb
@@ -104,14 +104,19 @@ ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("IMAGE_FEATURES", "read-only
 read_only_essential () {
     if [ -e ${IMAGE_ROOTFS}/etc/hosts ]; then
         mv ${IMAGE_ROOTFS}/etc/hosts ${IMAGE_ROOTFS}/etc/hosts0
-        ln -s ../run/systemd/resolve/hosts ${IMAGE_ROOTFS}/etc/hosts
     fi
+    ln -s ../run/systemd/resolve/hosts ${IMAGE_ROOTFS}/etc/hosts
+
     if [ -e ${IMAGE_ROOTFS}/etc/dnsmasq.conf ]; then
         mv ${IMAGE_ROOTFS}/etc/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf0
-        ln -s ../run/systemd/resolve/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf
     fi
-    rm -f ${IMAGE_ROOTFS}/etc/resolv.conf
+    ln -s ../run/systemd/resolve/dnsmasq.conf ${IMAGE_ROOTFS}/etc/dnsmasq.conf
+
+    if [ -e ${IMAGE_ROOTFS}/etc/resolv.conf ]; then
+        mv ${IMAGE_ROOTFS}/etc/resolv.conf ${IMAGE_ROOTFS}/etc/resolv.conf0
+    fi
     ln -s ../run/systemd/resolve/resolv.conf ${IMAGE_ROOTFS}/etc/resolv.conf
+
     if [ -e ${IMAGE_ROOTFS}/etc/system-id ]; then
         rm ${IMAGE_ROOTFS}/etc/system-id -f
     fi

--- a/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/meta-cube/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -10,7 +10,8 @@ ALLOW_EMPTY_${PN}-cube-shared = "1"
 pkg_postinst_${PN}-cube-shared () {
     # Be a nop if any other linux-firmware(-*) pkgs are found
     if [ ! -e $D/lib/firmware ]; then
-        mkdir -p $D/var/lib/cube/essential/lib/firmware
+        mkdir -p $D/var/lib/cube/essential/lib
         ln -sfr $D/var/lib/cube/essential/lib/firmware $D/lib/firmware
+        ln -sfr /opt/container/dom0/rootfs/lib/firmware $D/var/lib/cube/essential/lib/firmware
     fi
 }

--- a/meta-cube/recipes-support/dom0-init/files/firmware-sync
+++ b/meta-cube/recipes-support/dom0-init/files/firmware-sync
@@ -18,6 +18,21 @@ container_dir="/opt/container"
 # This allows for firmware to be upgraded by updating dom0
 refresh_cube_essential_firmware()
 {
+    # Check if the copy desitation is a link to the origin directory
+    # if so, skip the sync.
+    if [ -L /var/lib/cube/essential/lib/firmware ] ; then
+	# Now check if these point to the same location
+	a=$(stat -c %i /lib/firmware/.)
+	b=$(stat -c %i /var/lib/cube/essential/lib/firmware/.)
+	if [ "${a}" = "${b}" ] ; then
+	    exit 0
+	fi
+   fi
+    firmloc=$(readlink /var/lib/cube/essential/lib/firmware)
+    if [ "${firmloc}" = "../opt/container/dom0/rootfs/lib/firmware" -o "${firmloc}" = "/opt/container/dom0/rootfs/lib/firmware" ] ; then
+	exit 0
+    fi
+
     local dom0_rootfs="${container_dir}/dom0/rootfs"
 
     if [ ! -d "/var/lib/cube/essential/lib/firmware/" ]; then

--- a/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
+++ b/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
@@ -11,15 +11,18 @@ SRC_URI = "file://essential-autostart \
            file://reload-dom0-snapshot \
            file://reload-dom0-snapshot.service \
            file://daemonize-sigusr1-wait.c \
+	   file://essential-opt-mount.service \
+	   file://essential-opt-mount \
 "
 
 SRC_FILES_LIST = "essential-autostart \
                   reload-dom0-snapshot \
+                  essential-opt-mount \
 "
 
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "essential-autostart.service reload-dom0-snapshot.service"
+SYSTEMD_SERVICE_${PN} = "essential-autostart.service reload-dom0-snapshot.service essential-opt-mount.service"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
 systemd_postinst() {
@@ -48,6 +51,7 @@ do_install() {
     install -d ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/essential-autostart.service ${D}${systemd_unitdir}/system/
     install -m 0644 ${WORKDIR}/reload-dom0-snapshot.service ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/essential-opt-mount.service ${D}${systemd_unitdir}/system/
 }
 
 FILES_${PN} += "${sbin} \

--- a/meta-cube/recipes-support/essential-init/files/essential-autostart
+++ b/meta-cube/recipes-support/essential-init/files/essential-autostart
@@ -1,22 +1,5 @@
 #!/bin/bash
 
-# Check that /var/log/journal is writeable, else set it up
-touch /var/log/journal
-if [ $? != 0 ] ; then
-    mkdir -p /opt/container/.rootns/var/log/journal
-    mount -o bind /opt/container/.rootns/var/log/journal /var/log/journal
-fi
-
-# Check that /var/lib/cube is writeable, else set it up
-touch /var/lib/cube
-if [ $? != 0 ] ; then
-    mkdir -p /opt/container/.rootns/var/lib/cube
-    mount -o bind /opt/container/.rootns/var/lib/cube /var/lib/cube
-fi
-
-# Create directories in case they have not been setup yet
-mkdir -p /var/lib/cube/all /var/lib/cube/essential /var/lib/cube/local
-
 if [ "$1" = "stop" ] ; then
     pid=`/bin/machinectl show dom0 -p Leader --value`
     if [ ! -n "$pid" ] ; then

--- a/meta-cube/recipes-support/essential-init/files/essential-opt-mount
+++ b/meta-cube/recipes-support/essential-init/files/essential-opt-mount
@@ -27,3 +27,8 @@ fi
 
 # Create directories in case they have not been setup yet
 mkdir -p /var/lib/cube/all /var/lib/cube/essential /var/lib/cube/local
+# The default for the firmware is to point it to dom0
+if [ ! -e /var/lib/cube/essential/lib/firmware ] ; then
+    mkdir -p /var/lib/cube/essential/lib
+    ln -sf /opt/container/dom0/rootfs/lib/firmware /var/lib/cube/essential/lib/firmware
+fi

--- a/meta-cube/recipes-support/essential-init/files/essential-opt-mount
+++ b/meta-cube/recipes-support/essential-init/files/essential-opt-mount
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+mount /opt/container || exit -1
+
+grep ^/dev/root /etc/fstab |grep -qw ro
+USE_RO=$?
+
+if [ $USE_RO = 0 ] ; then
+    mkdir -p /opt/container/.rootns/var/log/journal
+    mount -o bind /opt/container/.rootns/var/log/journal /var/log/journal
+
+    mkdir -p /opt/container/.rootns/var/lib/cube
+    mount -o bind /opt/container/.rootns/var/lib/cube /var/lib/cube
+
+    mkdir -p /opt/container/.rootns/var/volatile/tmp
+    chmod 1777 /opt/container/.rootns/var/volatile/tmp
+    mount -o bind /opt/container/.rootns/var/volatile /var/volatile
+
+    # verify /run directories and copy files into tmpfs, if using read-only root
+    mkdir -p /run/systemd/resolve
+    for f in dnsmasq.conf resolv.conf hosts localtime timezone; do
+	if [ -L /etc/${f} ] && [ -e /etc/${f}0 ] && [ ! -e /run/systemd/resolve/${f} ] ; then
+	    cp /etc/${f}0 /run/systemd/resolve/${f}
+	fi
+    done
+fi
+
+# Create directories in case they have not been setup yet
+mkdir -p /var/lib/cube/all /var/lib/cube/essential /var/lib/cube/local

--- a/meta-cube/recipes-support/essential-init/files/essential-opt-mount.service
+++ b/meta-cube/recipes-support/essential-init/files/essential-opt-mount.service
@@ -1,0 +1,21 @@
+# Taken in part from systemd-remount-fs.service, because this
+# service needs to run immediately after it so as to allow
+# /lib/firmware to be available from:
+# /opt/container/dom0/rootfs/lib/firmware
+
+[Unit]
+Description=Essential Mount /opt/container
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-fsck-root.service
+Before=systemd-remount-fs.service local-fs-pre.target local-fs.target shutdown.target
+Wants=local-fs-pre.target
+ConditionPathExists=/etc/fstab
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/sbin/essential-opt-mount
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This series is really two separate changes, but they have to be stacked in order because one depends on the other. 

1)  The read-only root support requires creating a directory where we can store files that can be persistently modified.  They will be stored in /opt/container/.rootns

2) The /lib/firmware handling can be optimized to have no copy by default so as to improve the boot speed and ease of management when dealing with slow persistent (or read-only) devices for the "/" volume.