### PR TITLE
layer.conf: add LAYERSERIES_COMPAT `thud'

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,4 +12,5 @@ BBFILE_PRIORITY_overc = "1"
 # cause compatibility issues with other layers
 LAYERVERSION_overc = "1"
 LAYERDEPENDS_overc = "core"
+LAYERSERIES_COMPAT_overc = "thud"
 

--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -58,3 +58,4 @@ SYSVINIT_SCRIPTS_remove_pn-packagegroup-core-boot = "busybox-hwclock"
 # default, essential rootfs is read-only. To change it to read-write, please update
 # value to "read-write", then rebuild essential rootfs.
 OVERC_ESSENTIAL_MODE = "read-only"
+LAYERSERIES_COMPAT_cube = "thud"


### PR DESCRIPTION
Since `9ec5a8a layer.conf: Drop sumo from LAYERSERIES_CORENAMES' and
`9867924 layer.conf: Add thud to LAYERSERIES_CORENAMES' applied in oe-core,
add LAYERSERIES_COMPAT `thud'

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>