### PR TITLE
conf/layer.conf: conditionally set BBFILE_PATTERN

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,7 +5,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "overc"
-BBFILE_PATTERN_overc = "^${LAYERDIR}/"
+BBFILE_PATTERN_overc = "${@bb.utils.contains('DISTRO', 'overc', '^${LAYERDIR}/', '', d)}"
 BBFILE_PRIORITY_overc = "1"
 
 # This should only be incremented on significant changes that will

--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -5,7 +5,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "cube"
-BBFILE_PATTERN_cube = "^${LAYERDIR}/"
+BBFILE_PATTERN_cube = "${@bb.utils.contains('DISTRO', 'overc', '^${LAYERDIR}/', '', d)}"
 BBFILE_PRIORITY_cube = "8"
 
 BB_DANGLINGAPPENDS_WARNONLY ?= "true"


### PR DESCRIPTION
Conditionally set BBFILE_PATTERN as what we did for BBFILES.

Fixed when DISTRO != overc:
WARNING: No bb files matched BBFILE_PATTERN_cube '^/path/to/meta-overc/meta-cube/'
WARNING: No bb files matched BBFILE_PATTERN_overc '^/path/to/meta-overc/'

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>