### PR TITLE
packagegroups: Change from PACKAGE_ARCH to MACHINE_ARCH

### DIFF
--- a/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
@@ -10,8 +10,8 @@ PR = "r1"
 LICENSE = "MIT"
 
 # grr - packagegroup is special and wants to be allarch, which
-# doesn't work so well if we want to filter grub for x86 etc.
-PACKAGE_ARCH = "${TUNE_PKGARCH}"
+# doesn't work so well if we want to filter grub for MACHINE_FEATURES, etc.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 PACKAGES = "\

--- a/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-dom0.bb
@@ -9,8 +9,8 @@ DESCRIPTION = "Packages required to define domain 0 cube for OverC"
 LICENSE = "MIT"
 
 # grr - packagegroup is special and wants to be allarch, which
-# doesn't work so well if we want to filter grub for x86 etc.
-PACKAGE_ARCH = "${TUNE_PKGARCH}"
+# doesn't work so well if we want to filter grub for MACHINE_FEATURES, etc.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 require overc-common-pkgdefs.inc

--- a/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-essential.bb
@@ -9,8 +9,8 @@ DESCRIPTION = "Packages required to round out the native host system for OverC"
 LICENSE = "MIT"
 
 # grr - packagegroup is special and wants to be allarch, which
-# doesn't work so well if we want to filter grub for x86 etc.
-PACKAGE_ARCH = "${TUNE_PKGARCH}"
+# doesn't work so well if we want to filter grub for MACHINE_FEATURES, etc.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 require overc-common-pkgdefs.inc


### PR DESCRIPTION
Many of these groups have indirect checks to see if grub is available, based
on the MACHINE_FEATURES.  This can change from BSP to BSP, and thus the hash
and PR values for these recipes change.

Instead of permitting this indeterminite behavior, we want to make these
select packagegroups to be MACHINE_ARCH, so they will be unique to the needs
of the specific BSP they are building against.

Signed-off-by: Mark Hatle <mark.hatle@windriver.com>