### PR TITLE
dhcp: refresh patch context

### DIFF
--- a/meta-cube/recipes-connectivity/dhcp/dhcp/dhclient-Add-option-to-die-when-the-parent-process-e.patch
+++ b/meta-cube/recipes-connectivity/dhcp/dhcp/dhclient-Add-option-to-die-when-the-parent-process-e.patch
@@ -48,7 +48,7 @@ index 825ab00..592c69e 100644
 @@ -398,6 +402,8 @@ main(int argc, char **argv) {
  			no_dhclient_pid = 1;
  		} else if (!strcmp(argv[i], "--no-pid")) {
- 			no_pid_file = ISC_TRUE;
+ 			no_pid_file = true;
 +		} else if (!strcmp(argv[i], "--psig")) {
 +			psig = 1;
  		} else if (!strcmp(argv[i], "-cf")) {


### PR DESCRIPTION
Oe-core commit 5775e9ef2fce [dhcp: fix issue with new
bind changes] changed the context of the
dhclient-Add-option-to-die-when-the-parent-process-e.patch
which caused "Hunk #4 FAILED at 402." patching failure.

Fixup the patch context to avoid this.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>