### PR TITLE
conf: add 'remove-libtool' to INHERIT_DISTRO

### DIFF
--- a/conf/distro/overc.conf
+++ b/conf/distro/overc.conf
@@ -14,7 +14,7 @@ OVERC_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 OVERC_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_LIBC} ${OVERC_DEFAULT_DISTRO_FEATURES}"
-INHERIT_DISTRO ?= " debian devshell sstate license package-name"
+INHERIT_DISTRO ?= " debian devshell sstate license package-name remove-libtool"
 
 include conf/${TARGET_ARCH}.conf
 


### PR DESCRIPTION
This addition causes *.la files to be removed from packages unless a
recipe specifies REMOVE_LIBTOOL_LA=0. In general it is recognized that
*.la files are of little value and it is generally better to destroy
these files instead of packaging them (in -dev packages).

Upstream has added 'remove-libtool' to most/all of the distros they
make use of to perform build tests so we tend to be the only ones that
complain when a package is uprev'd or similar and new *.la files are
left unpackaged, causing a QA error. We could make this a QA warning
to prevent build failures, yet allow us to identify and fix these
issues, but like the rest of the world we should just start to destroy
and not care about *.la files.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>