### PR TITLE
distro: add 'polkit' to the distro features

### DIFF
--- a/conf/distro/overc.conf
+++ b/conf/distro/overc.conf
@@ -9,7 +9,7 @@ MAINTAINER = "Wind River <windriver@windriver.com>"
 
 TARGET_VENDOR = "-overc"
 
-OVERC_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland alsa argp bluetooth ext2 usbgadget usbhost wifi xattr nfs zeroconf pci x11 pam virtualization kvm"
+OVERC_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland alsa argp bluetooth ext2 usbgadget usbhost wifi xattr nfs zeroconf pci x11 pam virtualization kvm polkit"
 OVERC_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 OVERC_DEFAULT_EXTRA_RRECOMMENDS = "kernel-module-af-packet"
 


### PR DESCRIPTION
meta-openembedded commit 97a1a55f4755 [polkit: add polkit as a
required distro feature] requires us to include 'polkit' as a distro
feature. This is due to libvirt including the 'polkit' PACKAGECONFIG
as a result of the 'x11' distro feature that we already have set.

Fixes:
[21:33:32-0800] ERROR: Nothing PROVIDES 'polkit' (but meta-virtualization/recipes-extended/libvirt/libvirt_4.9.0.bb DEPENDS on or otherwise requires it)
[21:33:32-0800] polkit was skipped: missing required distro feature 'polkit' (not in DISTRO_FEATURES)
[21:33:32-0800] NOTE: Runtime target 'libvirt-python' is unbuildable, removing...
[21:33:32-0800] Missing or unbuildable dependency chain was: ['libvirt-python', 'polkit']

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>