### PR TITLE
overc-utils: RDEPEND on util-linux-X

### DIFF
--- a/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
@@ -71,5 +71,5 @@ FILES_${PN} += "/opt/${BPN} ${datadir}/bash-completion \
 FILES_overc-device-utils += "${sbindir}/cube-device ${sysconfdir}/udev ${sysconfdir}/cube-device"
 
 RDEPENDS_${PN} += "bash dtach nanomsg udev systemd-extra-utils jq overc-installer udocker \
-                   sed which grep \
+                   sed which grep util-linux-nsenter util-linux-column \
 "


### PR DESCRIPTION
I thought about doing this in the util-linux packagegroup but instead opted for the RDEPENDS in the overc-utils recipe as I think there is value in calling out direct dependencies. This approach is also preferred if we are looking to making images smaller. At any rate if folks don't agree I can change things around to put them in the packagegroup.

I ran some tests, listing containers, adding a container, configuring the container, running it, stopping it and deleting it. I also searched around for other breakage that this change to util-linux package might have created but didn't find anything.