### PR TITLE
packagegroup-util-linux: add util-linux-nsenter

### DIFF
--- a/meta-cube/recipes-core/packagegroups/packagegroup-util-linux.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-util-linux.bb
@@ -66,4 +66,5 @@ RDEPENDS_packagegroup-util-linux-misc = "\
     util-linux-bash-completion \
     util-linux-hwclock \
     util-linux-getopt \
+    util-linux-nsenter \
     "


### PR DESCRIPTION
I messed up and most have not rebuilt cube-essential when I tested the previous attempt at working around the new packages splits of util-linux. There are a few ways to accomplish the goal of adding nsenter to cube-essential, Bruce, if you believe another makes more sense go ahead and adjust as needed.