### PR TITLE
vim: drop relative directory use

### DIFF
--- a/meta-cube/recipes-support/vim/vim_%.bbappend
+++ b/meta-cube/recipes-support/vim/vim_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://vim-Make-text-mode-editing-Great-again.patch;patchdir=.."
+SRC_URI += "file://vim-Make-text-mode-editing-Great-again.patch"
 
 # Temporary workaround for absence upstream ; delete ASAP.
 SRC_URI[md5sum] = "2bfd304eabd99fc57629851cd96bdbfd"


### PR DESCRIPTION
The use of relative directories was dropped in oe-core commit
2eb66c1ff55a [vim: Rework to not rely on relative directories]. We
have to follow suit.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>