### PR TITLE
essential-init: drop custom systemd-postinst script

### DIFF
--- a/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
+++ b/meta-cube/recipes-support/essential-init/essential-init_1.0.bb
@@ -23,19 +23,6 @@ SRC_FILES_LIST = "essential-autostart \
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "essential-autostart.service reload-dom0-snapshot.service essential-opt-mount.service"
-SYSTEMD_AUTO_ENABLE_${PN} = "enable"
-
-systemd_postinst() {
-OPTS=""
-
-if [ -n "$D" ]; then
-    OPTS="--root=$D"
-fi
-
-if type systemctl >/dev/null 2>/dev/null; then
-	systemctl $OPTS ${SYSTEMD_AUTO_ENABLE} ${SYSTEMD_SERVICE}
-fi
-}
 
 do_compile() {
 	${CC} ${CFLAGS} ${LDFLAGS} -Wall ${WORKDIR}/daemonize-sigusr1-wait.c -o ${B}/daemonize-sigusr1-wait


### PR DESCRIPTION
Unfortunately there is no history that I can find on why we have a
custom systemd-postinst(), but it is now causing the build to fail:

  ERROR: cube-essential-0.3-r0 do_rootfs: Postinstall scriptlets of ['essential-init'] have failed. If the intention is to defer them to first boot,
  then please place them into pkg_postinst_ontarget_${PN} ().
  Deferring to first boot via 'exit 1' is no longer supported.
  Details of the failure are in .../tmp/work/genericx86_64-overc-linux/cube-essential/0.3-r0/temp/log.do_rootfs.

I don't believe the content of the custom postinst was doing anything
special that the systemd.bbclass doesn't already do and runtime tests
seem to validate this. I didn't test upgrading/installing these
packages on a running system but if the systemd.bbclass is that busted
it should be fixed and not worked around.

We can drop the setting of 'SYSTEMD_AUTO_ENABLE' since, as the
documentation states: Services are set up to start on boot
automatically unless you have set SYSTEMD_AUTO_ENABLE to "disable".

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>