### PR TITLE
cube-essential: include new systemd-container pkg to provide machinectl

### DIFF
--- a/meta-cube/recipes-core/images/cube-essential_0.3.bb
+++ b/meta-cube/recipes-core/images/cube-essential_0.3.bb
@@ -24,6 +24,7 @@ IMAGE_INSTALL += "packagegroup-core-boot \
 		  overc-conftools \
 		  rndmac \
 		  screen-getty \
+		  systemd-container \
 		  iw \
 		  essential-init \
 		  pflask \


### PR DESCRIPTION
It was observed that 'c3 list' was returning the status of cube-dom0
and cube-vrf as 'invalid'. Enabling verbose output we can clearly see
that machinectl was missing from cube-essential.

The oe-core commit ae3c8d938c261c92ecf06e2d09f7e32bc117ceb8 [systemd:
move "machines" symlinks to systemd-container] brought OE inline with
recent changes to how most distros were packaging systemd, but this
resulted in the missing machinectl.

Add the new 'systemd-container' package to the cube-essential image to
resolve this.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>