### PR TITLE
meta-cube: changed c3-[app/systemd]-container.inc to .bbclass

### DIFF
--- a/meta-cube/classes/c3-app-container.bbclass
+++ b/meta-cube/classes/c3-app-container.bbclass
@@ -1,8 +1,3 @@
-SUMMARY ?= "Sample application container"
-DESCRIPTION ?= "A small application container which will run \
-                the application defined in IMAGE_INSTALL."
-HOMEPAGE ?= "http://www.windriver.com"
-
 LICENSE ?= "MIT"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -10,8 +5,6 @@ IMAGE_FSTYPES ?= "tar.bz2"
 IMAGE_FSTYPES_remove = "live"
 
 TARGETNAME ?= "c3-app-container"
-
-IMAGE_INSTALL += ""
 
 IMAGE_FEATURES = ""
 

--- a/meta-cube/classes/c3-systemd-container.bbclass
+++ b/meta-cube/classes/c3-systemd-container.bbclass
@@ -1,17 +1,12 @@
-SUMMARY ?= "Sample systemd system container"
-DESCRIPTION ?= "A small systemd system container which will run \
-                the application defined in IMAGE_INSTALL."
-HOMEPAGE ?= "http://www.windriver.com"
-
 LICENSE ?= "MIT"
 LIC_FILES_CHKSUM ?= "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 IMAGE_FSTYPES ?= "tar.bz2"
 IMAGE_FSTYPES_remove = "live"
 
-TARGETNAME ?= "c3-systemd-container"
-
 IMAGE_INSTALL_append += "systemd"
+
+TARGETNAME ?= "c3-systemd-container"
 
 IMAGE_FEATURES = ""
 

--- a/meta-cube/recipes-core/images/c3-app-container_1.0.bb
+++ b/meta-cube/recipes-core/images/c3-app-container_1.0.bb
@@ -3,6 +3,6 @@ DESCRIPTION = "A small application container which will run \
                 ${C3_APP_CONTAINER_APP}."
 HOMEPAGE = "http://www.windriver.com"
 
-require c3-app-container.inc
+inherit c3-app-container
 
 IMAGE_INSTALL += "${C3_APP_CONTAINER_APP}"

--- a/meta-cube/recipes-core/images/c3-systemd-container_1.0.bb
+++ b/meta-cube/recipes-core/images/c3-systemd-container_1.0.bb
@@ -14,4 +14,4 @@ SERVICES_TO_DISABLE_append += "${C3_SYSTEMD_CONTAINER_DISABLE_SERVICES}"
 # Use local.conf to enable systemd services
 SERVICES_TO_ENABLE += "${C3_SYSTEMD_CONTAINER_ENABLE_SERVICES}"
 
-require c3-systemd-container.inc
+inherit c3-systemd-container

--- a/meta-cube/recipes-core/images/cube-vrf_0.1.bb
+++ b/meta-cube/recipes-core/images/cube-vrf_0.1.bb
@@ -5,7 +5,7 @@ routing functions are managed by this container."
 
 HOMEPAGE = "http://www.windriver.com"
 
-require recipes-core/images/c3-app-container.inc
+inherit c3-app-container
 
 IMAGE_INSTALL += " \
     openvswitch \


### PR DESCRIPTION
Workflow to build custom containers requires users to specify an
absolute path to locate the specific c3-[app/systemd]-container.inc
file. This is problematic for users creating their own recipes.
Changing from .inc to .bbclass will allow the build system to
look for the specific .bbclass file without explicitly specifying
a directory.