### PR TITLE
meta-overc: use libsdl2 instead of libsdl

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -262,7 +262,7 @@ BB_DISKMON_DIRS = "\
 # seen. The two lines below enable the SDL backend too. This assumes there is a
 # libsdl library available on your build system.
 PACKAGECONFIG_pn-qemu-native = "sdl"
-ASSUME_PROVIDED += "libsdl-native"
+ASSUME_PROVIDED += "libsdl2-native"
 
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to

--- a/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
+++ b/meta-cube/recipes-core/packagegroups/packagegroup-builder.bb
@@ -204,7 +204,7 @@ RDEPENDS_packagegroup-builder-graphics = "\
     libgl-dev \
     libglu \
     libglu-dev \
-    libsdl \
-    libsdl-dev \
+    libsdl2 \
+    libsdl2-dev \
     libx11-dev \
     "


### PR DESCRIPTION
The libsdl had been moved out of oe-core because it is obsolete. It is
safe to switch to libsdl2.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>