### PR TITLE
lxc: overc-system-agent: fixup QA warnings around missing scripting langs

### DIFF
--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -16,6 +16,8 @@ SRC_URI += " \
 # some point. Dropping for now to allow LXC to build.
 #    file://lxc-start-config-Add-lxc.uncontain-to-access-CAP_ADM.patch
 
+RDEPENDS_${PN} += "bash"
+
 do_install_append(){
 	# essential system controls the network, so lxc-net.service is redundant,
 	# remove the dependancy from lxc.service to reduce the boottime.

--- a/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
+++ b/meta-cube/recipes-support/overc-system-agent/overc-system-agent_1.2.bb
@@ -22,6 +22,7 @@ RDEPENDS_${PN} = "\
 	python3-jinja2 \
 	python3-markupsafe \
 	python3-werkzeug \
+	python3-core \
 	bash \
 	bc \
 	overc-installer \


### PR DESCRIPTION
We append lxc with a script ovs-up which lists bash in is "#!" yet lxc
didn't RDEPEND on bash. Similarly the overc-system-agent has python3
in one of its script's "#!" lines yet did not RDEPEND
python3-core. This resulted in QA warnings. Add the missing RDEPENDS.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>