### PR TITLE
layer.conf(s): modify BBFILE_PATTERN

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,7 +5,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${@bb.utils.contains('DISTRO', 'overc', '${LAYERDIR}/recipes-*/*/*.bb  ${LAYERDIR}/recipes-*/*/*.bbappend', '', d)}"
 
 BBFILE_COLLECTIONS += "overc"
-BBFILE_PATTERN_overc = "${@bb.utils.contains('DISTRO', 'overc', '^${LAYERDIR}/', '', d)}"
+BBFILE_PATTERN_overc = "^${LAYERDIR}/"
 BBFILE_PRIORITY_overc = "1"
 
 # This should only be incremented on significant changes that will

--- a/meta-cube/conf/layer.conf
+++ b/meta-cube/conf/layer.conf
@@ -5,7 +5,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${@bb.utils.contains('DISTRO', 'overc', '${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend', '', d)}"
 
 BBFILE_COLLECTIONS += "cube"
-BBFILE_PATTERN_cube = "${@bb.utils.contains('DISTRO', 'overc', '^${LAYERDIR}/', '', d)}"
+BBFILE_PATTERN_cube = "^${LAYERDIR}/"
 BBFILE_PRIORITY_cube = "8"
 
 BB_DANGLINGAPPENDS_WARNONLY ?= "true"


### PR DESCRIPTION
Allow 'No bb files match...' warning to display layer location.

Signed-off-by: Joe Slater <joe.slater@windriver.com>