### PR TITLE
distro: drop the second dash

### DIFF
--- a/conf/distro/overc.conf
+++ b/conf/distro/overc.conf
@@ -2,7 +2,7 @@ DISTRO = "overc"
 DISTRO_NAME = "overc"
 DISTRO_VERSION = "1.0"
 DISTRO_CODENAME = ""
-SDK_VENDOR = "-overc-sdk"
+SDK_VENDOR = "-overcsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
 
 MAINTAINER = "Wind River <windriver@windriver.com>"


### PR DESCRIPTION
Currently we are seeing the error:
    SDK_VENDOR should be of the form '-foosdk' with a single dash

This is showing up now due to oe-core commit b0efd8d4d0db [sanity:
check the format of SDK_VENDOR] added to fix [ YOCTO #13573 ] which
basically enforces the use of a single dash in SDK_VENDOR. We follow
the guidance and drop the second dash.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>