### PR TITLE
overc-utils: add missing RDEPENDS for util-linux-setsid

### DIFF
--- a/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
@@ -71,5 +71,5 @@ FILES_${PN} += "/opt/${BPN} ${datadir}/bash-completion \
 FILES_overc-device-utils += "${sbindir}/cube-device ${sysconfdir}/udev ${sysconfdir}/cube-device"
 
 RDEPENDS_${PN} += "bash dtach nanomsg udev systemd-extra-utils jq overc-installer udocker \
-                   sed which grep util-linux-nsenter util-linux-column \
+                   sed which grep util-linux-nsenter util-linux-column util-linux-setsid \
 "


### PR DESCRIPTION
We were seeing the following error when using 'c3 start -a' to start a
container:
    /usr/sbin/c3-ctl: line 1918: setsid: command not found

This is more fallout of util-linux moving to one package per
binary. Add the missing RDEPENDS.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>