### PR TITLE
cube-network hook: Fix pid detect for cube_vrf

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/cube-network
+++ b/meta-cube/recipes-support/overc-conftools/source/cube-network
@@ -52,11 +52,9 @@ interface_exists() {
 
 # Get the cube-vrf 'init' PID
 get_cube_vrf_pid() {
-    # The "true" parent will have init/systemd as their parent
-    cube_vrf_ppid=$(ps -ef|grep -E "[0-9]+\ +1\ .*pflask.*cube-vrf"|grep -v grep|awk '{print $2}')
-    # There can be multiple pids associated with the ppid at startup but we only care about
-    # the one either launching or running 'docker-init', so filter accordingly
-    echo $(ps -ef|grep -E "[0-9]+\ +${cube_vrf_ppid}\ +.*docker-init"|grep -v grep|awk '{print $2}')
+    local pid
+    pid=$(cat /var/run/systemd/machines/cube-vrf |grep ^LEADER)
+    echo ${pid#LEADER=}
 }
 
 get_vrf_container() {


### PR DESCRIPTION
Looking up the pid with ps causes race problems with processes that
come and go leading to occasional boot failures.

The example from real data from the PID routine with a log file from a
failed boot replacing the ps output.

=====
get_cube_vrf_pid() {
    # The "true" parent will have init/systemd as their parent
    cube_vrf_ppid=$(cat log-395 |grep -E "[0-9]+\ +1\ .*pflask.*cube-vrf"|grep -v grep|awk '{print $2}')
    # There can be multiple pids associated with the ppid at startup but we only care about
    # the one either launching or running 'docker-init', so filter accordingly
    echo $(cat log-395|grep -E "[0-9]+\ +${cube_vrf_ppid}\ +.*docker-init"|grep -v grep|awk '{print $2}')
}
====
% echo $cube_vrf_ppid
381 383
% get_cube_vrf_pid
383 393

====  ps entries in question ====
% egrep -e "(381|383|393)" log-395

root         381       1  1 23:23 ?        00:00:00 pflask --mount bind:/opt/container:/opt/container --mount bind:/var/lib/cube:/var/lib/cube --mount bind:/proc/sys:/proc/sys --netif -p cube-vrf --uncontain -d --escape-char=255 --root /opt/container/cube-vrf/rootfs --hook=/bin/sh -c '/usr/libexec/cube/hooks.d/cube-network nslinkup %s' --hook=/bin/sh -c '/usr/libexec/cube/hooks.d/cube-netconfig vrf %s' -- /usr/bin/docker-init /sbin/vrf-init
root         383     381  1 23:23 pts/1    00:00:00 pflask --mount bind:/opt/container:/opt/container --mount bind:/var/lib/cube:/var/lib/cube --mount bind:/proc/sys:/proc/sys --netif -p cube-vrf --uncontain -d --escape-char=255 --root /opt/container/cube-vrf/rootfs --hook=/bin/sh -c '/usr/libexec/cube/hooks.d/cube-network nslinkup %s' --hook=/bin/sh -c '/usr/libexec/cube/hooks.d/cube-netconfig vrf %s' -- /usr/bin/docker-init /sbin/vrf-init
root         393     381  1 23:23 ?        00:00:00 sh -c /bin/sh -c '/usr/libexec/cube/hooks.d/cube-network nslinkup /opt/container/cube-vrf 383' 2>&1
root         395     393 11 23:23 ?        00:00:00 /bin/bash /usr/libexec/cube/hooks.d/cube-network nslinkup /opt/container/cube-vrf 383
root         488     395  0 23:23 ?        00:00:00 /bin/bash /usr/libexec/cube/hooks.d/cube-network nslinkup /opt/container/cube-vrf 383
root         489     488  0 23:23 ?        00:00:00 /bin/bash /usr/libexec/cube/hooks.d/cube-network nslinkup /opt/container/cube-vrf 383

===========================

For solving the problem we can take advantage of the fact that the
cube-vrf is a pflask and optimize the routine to use the machinectl
data directly.

[ Issue: LIN1019-3369 ]

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>