### PR TITLE
fixes for usrmerge and the latest oe-core util-linux split 

### DIFF
--- a/meta-cube/recipes-connectivity/cube-update/cube-update/config.default
+++ b/meta-cube/recipes-connectivity/cube-update/cube-update/config.default
@@ -1,4 +1,3 @@
-#!/bin/false  This file must be sourced
 #
 # Copyright (C) 2015 Wind River Systems, Inc.
 #

--- a/meta-cube/recipes-containers/pflask/pflask_git.bb
+++ b/meta-cube/recipes-containers/pflask/pflask_git.bb
@@ -67,6 +67,7 @@ do_install() {
 		extra_ldflags=$(pkg-config --libs dbus-1)
 	fi
 
-	oe_runmake install DEFINES="${EXTRA_DEFINES_${PN}}" CFLAGS="${CFLAGS} ${extra_cflags}" LIB_SH="${extra_ldflags}"
+	oe_runmake install DEFINES="${EXTRA_DEFINES_${PN}}" CFLAGS="${CFLAGS} \
+             ${extra_cflags}" LIB_SH="${extra_ldflags}" BINDIR=${D}${base_bindir}
 }
 

--- a/meta-cube/recipes-core/rndmac/rndmac_0.1.bb
+++ b/meta-cube/recipes-core/rndmac/rndmac_0.1.bb
@@ -15,7 +15,7 @@ SRC_URI = "file://LICENSE.GPL2 \
 
 S = "${WORKDIR}"
 
-FILES_${PN} += "/lib/systemd"
+FILES_${PN} += "${systemd_unitdir}/system/rndmac.service"
 
 do_install() {
 	oe_runmake DEST=${D}${bindir} install

--- a/meta-cube/recipes-extended/screen-getty/files/Makefile
+++ b/meta-cube/recipes-extended/screen-getty/files/Makefile
@@ -2,6 +2,7 @@
 OBJS = screen-getty agetty-shell
 
 DEST=/
+SBIN=/sbin
 
 all: $(OBJS)
 
@@ -18,8 +19,8 @@ agetty-shell: agetty-shell.o
 	$(CC) $(LDFLAGS) -Wall -o $@ $^
 
 install: $(OBJS)
-	install -d $(DEST)/sbin
+	install -d $(DEST)$(SBIN)
 	install -d $(DEST)/etc/default
 	install -m 0644 screen-gettyrc $(DEST)/etc/default
-	install -m 0755 screen-getty $(DEST)/sbin
-	install -m 0755 agetty-shell $(DEST)/sbin
+	install -m 0755 screen-getty $(DEST)$(SBIN)
+	install -m 0755 agetty-shell $(DEST)$(SBIN)

--- a/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
+++ b/meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb
@@ -72,4 +72,5 @@ FILES_overc-device-utils += "${sbindir}/cube-device ${sysconfdir}/udev ${sysconf
 
 RDEPENDS_${PN} += "bash dtach nanomsg udev systemd-extra-utils jq overc-installer udocker \
                    sed which grep util-linux-nsenter util-linux-column util-linux-setsid \
+                   util-linux-script \
 "

--- a/meta-cube/recipes-support/vrf-init/vrf-init_0.1.bb
+++ b/meta-cube/recipes-support/vrf-init/vrf-init_0.1.bb
@@ -13,8 +13,8 @@ SRC_URI = " \
 "
 
 do_install() {
-    install -d ${D}/sbin
-    install -m 0755 ${WORKDIR}/vrf-init ${D}/sbin/vrf-init
+    install -d ${D}${base_sbindir}
+    install -m 0755 ${WORKDIR}/vrf-init ${D}${base_sbindir}/vrf-init
 
     install -d ${D}/${prefix}
     install -d ${D}/${bindir}


### PR DESCRIPTION
      screen-getty: Add support for usrmerge
      rndmac: fix usrmerge problems
      pflask: Fix to work with usrmerge
      vrf-init: Fix to build with usrmerge
      cube-update: Remove #!/bin/false from config.default
      overc-utils: dom0 needs to depend on util-linux-script

 .../recipes-connectivity/cube-update/cube-update/config.default    | 1 -
 meta-cube/recipes-containers/pflask/pflask_git.bb                  | 3 ++-
 meta-cube/recipes-core/rndmac/rndmac_0.1.bb                        | 2 +-
 meta-cube/recipes-extended/screen-getty/files/Makefile             | 7 ++++---
 meta-cube/recipes-support/overc-utils/overc-utils_1.0.bb           | 1 +
 meta-cube/recipes-support/vrf-init/vrf-init_0.1.bb                 | 4 ++--
 6 files changed, 10 insertions(+), 8 deletions(-)
