### PR TITLE
A few fixups in the overc-system-agent

### DIFF
--- a/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
+++ b/meta-cube/recipes-support/overc-system-agent/files/overc-system-agent-1.2/Overc/backends/btrfs.py
@@ -25,6 +25,8 @@ class Btrfs(Utils):
             self.kernel = "/boot/fitImage"
         elif self._path_exists('/boot/kernel7.img', True):
             self.kernel = "/boot/kernel7.img"
+        elif self._path_exists('/boot/Image', True):
+            self.kernel = "/boot/Image"
 
         self.kernel_md5 = self._compute_checksum(self.kernel, True)
 


### PR DESCRIPTION
The first is to add 'Image' to the list of kernel image files. The second is to allow things to continue to work and not generate a nasty python backtrace when a kernel file is not found.