### PR TITLE
cube-ctl: avoid 'ln' errors running prep

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-ctl
+++ b/meta-cube/recipes-support/overc-utils/source/cube-ctl
@@ -782,7 +782,9 @@ tweak_container_devices()
 
 	for v in ${vts}; do
 	    vty_num=$(echo $v | cut -f1 -d: | sed 's%/dev/tty%%')
-	    ln -sf /lib/systemd/system/getty@.service ${container_storage}/${container_name}/rootfs/etc/systemd/system/getty.target.wants/getty@tty${vty_num}.service
+	    if [ $(echo $vty_num | grep -Ec "^[0-9]+$") -eq 1 ]; then
+		ln -sf /lib/systemd/system/getty@.service ${container_storage}/${container_name}/rootfs/etc/systemd/system/getty.target.wants/getty@tty${vty_num}.service
+	    fi
 	done
 
 	sed -i "s%ConditionPathExists=/dev/tty0%#ConditionPathExists=/dev/tty0%g" ${container_storage}/${container_name}/rootfs/lib/systemd/system/getty@.service


### PR DESCRIPTION
Not all devices conform to "/dev/tty<num>" so if you happen to run
'cube-ctl prep' on say dom0 you will get 'ln' errors as we attempt to
symlink files like:

/etc/systemd/system/getty.target.wants/getty@tty/dev/loop-control.service

We check to ensure we only attempt to create symlinks when the
matching is successful and we extract only a number.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>